### PR TITLE
Update jackson-json-reference

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,8 +98,8 @@ def common: Seq[Setting[_]] = bintrayPublishSettings ++ Seq(
     "zalando-maven" at "https://dl.bintray.com/zalando/maven"
   ),
   licenses                       += ("MIT", url("http://opensource.org/licenses/MIT")),
-  publishMavenStyle              := false,
-  repository in bintray          := "sbt-plugins",
+  publishMavenStyle              := true,
+  repository in bintray          := "maven",
   bintrayOrganization in bintray := Some("zalando")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val compiler = (project in file("compiler"))
       "org.scala-lang" % "scala-library" % scalaVersion.value,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "org.scalacheck" %% "scalacheck" % "1.12.5",
-      "me.andrz.jackson" % "jackson-json-reference" % "0.1.2",
+      "me.andrz.jackson" % "jackson-json-reference-core" % "0.2.1",
       "de.zalando" %% "beard" % "0.0.6"
     )
   )
@@ -95,7 +95,6 @@ def common: Seq[Setting[_]] = bintrayPublishSettings ++ Seq(
   autoScalaLibrary := true,
   resolvers ++= Seq(
     "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
-    "jackson-json-reference" at "https://dl.bintray.com/slavaschmidt/maven",
     "zalando-maven" at "https://dl.bintray.com/zalando/maven"
   ),
   licenses                       += ("MIT", url("http://opensource.org/licenses/MIT")),

--- a/compiler/src/test/scala/de/zalando/swagger/StrictParseExamplesTest.scala
+++ b/compiler/src/test/scala/de/zalando/swagger/StrictParseExamplesTest.scala
@@ -11,11 +11,8 @@ class StrictParseExamplesTest extends FunSpec with MustMatchers {
   val fixtures = new File("compiler/src/test/resources/examples").listFiles ++
     new File("compiler/src/test/resources/schema_examples").listFiles
 
-  // TODO enable these tests after jackson-json-reference is fixed
-  val disabledTests = Seq("body_to_ref_recurse.api.yaml")
-
   describe("Strict Swagger Parser") {
-    fixtures.filter(f => f.getName.endsWith(".yaml") && !disabledTests.contains(f.getName)).foreach { file =>
+    fixtures.filter(_.getName.endsWith(".yaml")).foreach { file =>
       it(s"should parse the yaml swagger file ${file.getName} as specification") {
         val result = StrictYamlParser.parse(file)
         result._1 mustBe a [URI]


### PR DESCRIPTION
I deployed the new version of jackson-son-reference-core into the Zalando's repo. This way we can get rid of one of additional repositories and keep this dependency in control until stable version is publicly available.