### PR TITLE
#26, Support for multiple file specifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,16 @@ notifications:
 jdk:
   - oraclejdk8
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 before_install:
-  - pip install --user codecov
+#  - pip install --user codecov
 
 after_success:
-  - codecov
+#  - codecov
 
 script:
-  - sbt compile test:compile test
-  #  TODO Disabled because it fails _sometimes_ in travis.
-  # +publishLocal scripted
+  - sbt compile test:compile test +publishLocal scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ after_success:
 #  - codecov
 
 script:
-  - sbt -jvm-opts travis/jvmopts compile test:compile test +publishLocal scripted
+  - sbt -jvm-opts travis/jvmopts compile test +publishLocal scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ after_success:
 #  - codecov
 
 script:
-  - sbt compile test:compile test +publishLocal scripted
+  - sbt -jvm-opts travis/jvmopts compile test:compile test +publishLocal scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ notifications:
 jdk:
   - oraclejdk8
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
-
 before_install:
 #  - pip install --user codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ notifications:
 jdk:
   - oraclejdk8
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 before_install:
 #  - pip install --user codecov
 

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val plugin = (project in file("plugin"))
       val b = (publishLocal in compiler).value
       val c = publishLocal.value
     },
-    scriptedBufferLog := true
+    scriptedBufferLog := false
   )
   .dependsOn(compiler)
 

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val plugin = (project in file("plugin"))
       val b = (publishLocal in compiler).value
       val c = publishLocal.value
     },
-    scriptedBufferLog := false
+    scriptedBufferLog := true
   )
   .dependsOn(compiler)
 

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,8 @@ lazy val plugin = (project in file("plugin"))
       val a = (publishLocal in api).value
       val b = (publishLocal in compiler).value
       val c = publishLocal.value
-    }
+    },
+    scriptedBufferLog := false
   )
   .dependsOn(compiler)
 

--- a/compiler/src/main/scala/de/zalando/apifirst/generators/commonDataSteps.scala
+++ b/compiler/src/main/scala/de/zalando/apifirst/generators/commonDataSteps.scala
@@ -55,6 +55,7 @@ trait CommonDataStep extends EnrichmentStep[Type] with CommonData {
 
   override def steps = types +: super.steps
 
+  @tailrec
   private def avoidClashes(table: DenotationTable, name: String)
                           (names: Iterable[String] = table.values.map(_ (COMMON)(TYPE_NAME).toString)): String =
     if (names.exists(_.equalsIgnoreCase(name))) avoidClashes(table, name + "NameClash")(names) else name
@@ -83,6 +84,8 @@ trait CommonData {
         case _ => useType(ref, suffix, "")
       }
     case p: PrimitiveType => useType(t.name, suffix, "")
+    case TypeDef(name, _, _) if name.isDefinition  && ! r.isDefinition =>
+      useType(name, suffix, "")
     case _ => useType(r, suffix, "")
   }
 

--- a/compiler/src/main/scala/de/zalando/apifirst/naming.scala
+++ b/compiler/src/main/scala/de/zalando/apifirst/naming.scala
@@ -49,12 +49,14 @@ object naming {
     val tokens = parts
     val pointer = this
     lazy val isResponsePath = parts.contains(responses)
+    lazy val isDefinition = parts.headOption.exists(_ == definitions)
     lazy val isTopResponsePath = parts.last == responses
   }
 
 
   object Reference {
     val responses = "responses"
+    val definitions = "definitions"
     val delimiter = "⌿"
     val root: Reference = Reference(List.empty)
     def apply(base: String, s: Reference): Reference = s

--- a/compiler/src/test/resources/examples/parts/split.petstore.definitions.json
+++ b/compiler/src/test/resources/examples/parts/split.petstore.definitions.json
@@ -1,0 +1,46 @@
+{
+  "definitions": {
+    "User": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "username": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "User Status"
+        }
+      }
+    },
+    "Category": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/compiler/src/test/resources/examples/parts/split.petstore.definitions.yaml
+++ b/compiler/src/test/resources/examples/parts/split.petstore.definitions.yaml
@@ -1,0 +1,72 @@
+definitions:
+  User:
+    properties:
+      id:
+        type: integer
+        format: int64
+      username:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      email:
+        type: string
+      password:
+        type: string
+      phone:
+        type: string
+      userStatus:
+        type: integer
+        format: int32
+        description: User Status
+  Pet:
+    required:
+      - name
+      - photoUrls
+    properties:
+      id:
+        type: integer
+        format: int64
+      category:
+        $ref: "split.petstore.definitions.json#/definitions/Category"
+      name:
+        type: string
+        example: doggie
+      photoUrls:
+        type: array
+        items:
+          type: string
+      tags:
+        type: array
+        items:
+          $ref: "#/definitions/Tag"
+      status:
+        type: string
+        description: pet status in the store
+  Tag:
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+  Order:
+    properties:
+      id:
+        type: integer
+        format: int64
+      petId:
+        type: integer
+        format: int64
+      quantity:
+        type: integer
+        format: int32
+      shipDate:
+        type: string
+        format: date-time
+      status:
+        type: string
+        description: Order Status
+      complete:
+        type: boolean

--- a/compiler/src/test/resources/examples/split.petstore.api.yaml
+++ b/compiler/src/test/resources/examples/split.petstore.api.yaml
@@ -1,0 +1,491 @@
+swagger: "2.0"
+info:
+  version: "1.0.0"
+  title: Swagger Petstore
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: apiteam@wordnik.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.wordnik.com
+basePath: /v2
+schemes:
+  - http
+x-api-first-error-mapping:
+  405:
+    - java.lang.IllegalArgumentException
+    - java.lang.IndexOutOfBoundsException
+paths:
+  /pets:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+      responses:
+        "405":
+          description: Validation exception
+        "404":
+          description: Pet not found
+        "400":
+          description: Invalid ID supplied
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma seperated strings
+      operationId: findPetsByStatus
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: status
+          description: Status values that need to be considered for filter
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: tags
+          description: Tags to filter by
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/{petId}:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
+      operationId: getPetById
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: petId
+          description: ID of pet that needs to be fetched
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "404":
+          description: Pet not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+        "400":
+          description: Invalid ID supplied
+      security:
+        - api_key: []
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ""
+      operationId: updatePetWithForm
+      consumes:
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: petId
+          description: ID of pet that needs to be updated
+          required: true
+          type: string
+        - in: formData
+          name: name
+          description: Updated name of the pet
+          required: true
+          type: string
+        - in: formData
+          name: status
+          description: Updated status of the pet
+          required: true
+          type: string
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ""
+      operationId: deletePet
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: header
+          name: api_key
+          description: ""
+          required: true
+          type: string
+        - in: path
+          name: petId
+          description: Pet id to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /stores/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: order placed for purchasing the pet
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Order"
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Order"
+        "400":
+          description: Invalid Order
+  /stores/order/{orderId}:
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+      operationId: getOrderById
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: orderId
+          description: ID of pet that needs to be fetched
+          required: true
+          type: string
+      responses:
+        "404":
+          description: Order not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Order"
+        "400":
+          description: Invalid ID supplied
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: orderId
+          description: ID of the order that needs to be deleted
+          required: true
+          type: string
+      responses:
+        "404":
+          description: Order not found
+        "400":
+          description: Invalid ID supplied
+  /users:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: Created user object
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithArrayInput
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: List of user object
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: List of user object
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: username
+          description: The user name for login
+          required: false
+          type: string
+        - in: query
+          name: password
+          description: The password for login in clear text
+          required: false
+          type: string
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: string
+        "400":
+          description: Invalid username/password supplied
+  /users/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        default:
+          description: successful operation
+  /users/{username}:
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          type: string
+      responses:
+        "404":
+          description: User not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+        "400":
+          description: Invalid username supplied
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: name that need to be deleted
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Updated user object
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+      responses:
+        "404":
+          description: User not found
+        "400":
+          description: Invalid user supplied
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be deleted
+          required: true
+          type: string
+      responses:
+        "404":
+          description: User not found
+        "400":
+          description: Invalid username supplied
+securityDefinitions:
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header
+  petstore_auth:
+    type: oauth2
+    authorizationUrl: http://petstore.swagger.wordnik.com/api/oauth/dialog
+    flow: implicit
+    scopes:
+      write_pets: modify pets in your account
+      read_pets: read your pets
+

--- a/compiler/src/test/resources/expected_results/controllers/split.petstore.api.yaml.base.scala
+++ b/compiler/src/test/resources/expected_results/controllers/split.petstore.api.yaml.base.scala
@@ -1,0 +1,888 @@
+package split.petstore.api.yaml
+
+import play.api.mvc.{Action, Controller, Results}
+import play.api.http.Writeable
+import Results.Status
+import de.zalando.play.controllers.{PlayBodyParsing, ParsingError}
+import PlayBodyParsing._
+import scala.util._
+import de.zalando.play.controllers.ArrayWrapper
+import org.joda.time.DateTime
+
+import de.zalando.play.controllers.PlayPathBindables
+
+
+
+
+trait SplitPetstoreApiYamlBase extends Controller with PlayBodyParsing {
+    private type findPetsByTagsActionRequestType       = (PetsFindByStatusGetStatus)
+    private type findPetsByTagsActionType              = findPetsByTagsActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusfindPetsByTags: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def findPetsByTagsAction = (f: findPetsByTagsActionType) => (tags: PetsFindByStatusGetStatus) => Action { 
+        val findPetsByTagsResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                400 -> anyToWritable[Null], 
+                200 -> anyToWritable[Seq[Pet]]
+        )
+        
+
+            val result =
+                    new PetsFindByTagsGetValidator(tags).errors match {
+                        case e if e.isEmpty => processValidfindPetsByTagsRequest(f)((tags))(possibleWriters, findPetsByTagsResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(findPetsByTagsResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidfindPetsByTagsRequest[T <: Any](f: findPetsByTagsActionType)(request: findPetsByTagsActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusfindPetsByTags orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val findPetsByTagsWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type placeOrderActionRequestType       = (StoresOrderPostBody)
+    private type placeOrderActionType              = placeOrderActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusplaceOrder: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+        private def placeOrderParser(maxLength: Int = parse.DefaultMaxTextLength) = optionParser[Order]("application/json", "Invalid StoresOrderPostBody", maxLength)
+
+    def placeOrderAction = (f: placeOrderActionType) => Action(placeOrderParser()) { request =>
+        val placeOrderResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                400 -> anyToWritable[Null], 
+                200 -> anyToWritable[Order]
+        )
+        val body = request.body
+        
+
+            val result =
+                    new StoresOrderPostValidator(body).errors match {
+                        case e if e.isEmpty => processValidplaceOrderRequest(f)((body))(possibleWriters, placeOrderResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(placeOrderResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidplaceOrderRequest[T <: Any](f: placeOrderActionType)(request: placeOrderActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusplaceOrder orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val placeOrderWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type createUserActionRequestType       = (UsersUsernamePutBody)
+    private type createUserActionType              = createUserActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatuscreateUser: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+        private def createUserParser(maxLength: Int = parse.DefaultMaxTextLength) = optionParser[User]("application/json", "Invalid UsersUsernamePutBody", maxLength)
+
+    def createUserAction = (f: createUserActionType) => Action(createUserParser()) { request =>
+        val createUserResponseMimeType    = "application/json"
+
+        val possibleWriters = Map.empty[Int,String => Writeable[Any]].withDefaultValue(anyToWritable[Null])
+        val body = request.body
+        
+
+            val result =
+                    new UsersPostValidator(body).errors match {
+                        case e if e.isEmpty => processValidcreateUserRequest(f)((body))(possibleWriters, createUserResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(createUserResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidcreateUserRequest[T <: Any](f: createUserActionType)(request: createUserActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatuscreateUser orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val createUserWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type createUsersWithListInputActionRequestType       = (UsersCreateWithListPostBody)
+    private type createUsersWithListInputActionType              = createUsersWithListInputActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatuscreateUsersWithListInput: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+        private def createUsersWithListInputParser(maxLength: Int = parse.DefaultMaxTextLength) = optionParser[UsersCreateWithListPostBodyOpt]("application/json", "Invalid UsersCreateWithListPostBody", maxLength)
+
+    def createUsersWithListInputAction = (f: createUsersWithListInputActionType) => Action(createUsersWithListInputParser()) { request =>
+        val createUsersWithListInputResponseMimeType    = "application/json"
+
+        val possibleWriters = Map.empty[Int,String => Writeable[Any]].withDefaultValue(anyToWritable[Null])
+        val body = request.body
+        
+
+            val result =
+                    new UsersCreateWithListPostValidator(body).errors match {
+                        case e if e.isEmpty => processValidcreateUsersWithListInputRequest(f)((body))(possibleWriters, createUsersWithListInputResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(createUsersWithListInputResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidcreateUsersWithListInputRequest[T <: Any](f: createUsersWithListInputActionType)(request: createUsersWithListInputActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatuscreateUsersWithListInput orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val createUsersWithListInputWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type getUserByNameActionRequestType       = (String)
+    private type getUserByNameActionType              = getUserByNameActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusgetUserByName: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def getUserByNameAction = (f: getUserByNameActionType) => (username: String) => Action { 
+        val getUserByNameResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                404 -> anyToWritable[Null], 
+                400 -> anyToWritable[Null], 
+                200 -> anyToWritable[User]
+        )
+        
+
+            val result =
+                    new UsersUsernameGetValidator(username).errors match {
+                        case e if e.isEmpty => processValidgetUserByNameRequest(f)((username))(possibleWriters, getUserByNameResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(getUserByNameResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidgetUserByNameRequest[T <: Any](f: getUserByNameActionType)(request: getUserByNameActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusgetUserByName orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val getUserByNameWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type updateUserActionRequestType       = (String, UsersUsernamePutBody)
+    private type updateUserActionType              = updateUserActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusupdateUser: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+        private def updateUserParser(maxLength: Int = parse.DefaultMaxTextLength) = optionParser[User]("application/json", "Invalid UsersUsernamePutBody", maxLength)
+
+    def updateUserAction = (f: updateUserActionType) => (username: String) => Action(updateUserParser()) { request =>
+        val updateUserResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                404 -> anyToWritable[Null], 
+                400 -> anyToWritable[Null]
+        )
+        val body = request.body
+        
+
+            val result =
+                    new UsersUsernamePutValidator(username, body).errors match {
+                        case e if e.isEmpty => processValidupdateUserRequest(f)((username, body))(possibleWriters, updateUserResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(updateUserResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidupdateUserRequest[T <: Any](f: updateUserActionType)(request: updateUserActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusupdateUser orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val updateUserWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type deleteUserActionRequestType       = (String)
+    private type deleteUserActionType              = deleteUserActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusdeleteUser: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def deleteUserAction = (f: deleteUserActionType) => (username: String) => Action { 
+        val deleteUserResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                404 -> anyToWritable[Null], 
+                400 -> anyToWritable[Null]
+        )
+        
+
+            val result =
+                    new UsersUsernameDeleteValidator(username).errors match {
+                        case e if e.isEmpty => processValiddeleteUserRequest(f)((username))(possibleWriters, deleteUserResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(deleteUserResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValiddeleteUserRequest[T <: Any](f: deleteUserActionType)(request: deleteUserActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusdeleteUser orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val deleteUserWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type updatePetActionRequestType       = (PetsPostBody)
+    private type updatePetActionType              = updatePetActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusupdatePet: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+        private def updatePetParser(maxLength: Int = parse.DefaultMaxTextLength) = optionParser[Pet]("application/json", "Invalid PetsPostBody", maxLength)
+
+    def updatePetAction = (f: updatePetActionType) => Action(updatePetParser()) { request =>
+        val updatePetResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                405 -> anyToWritable[Null], 
+                404 -> anyToWritable[Null], 
+                400 -> anyToWritable[Null]
+        )
+        val body = request.body
+        
+
+            val result =
+                    new PetsPutValidator(body).errors match {
+                        case e if e.isEmpty => processValidupdatePetRequest(f)((body))(possibleWriters, updatePetResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(updatePetResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidupdatePetRequest[T <: Any](f: updatePetActionType)(request: updatePetActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusupdatePet orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val updatePetWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type addPetActionRequestType       = (PetsPostBody)
+    private type addPetActionType              = addPetActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusaddPet: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+        private def addPetParser(maxLength: Int = parse.DefaultMaxTextLength) = optionParser[Pet]("application/json", "Invalid PetsPostBody", maxLength)
+
+    def addPetAction = (f: addPetActionType) => Action(addPetParser()) { request =>
+        val addPetResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                405 -> anyToWritable[Null]
+        )
+        val body = request.body
+        
+
+            val result =
+                    new PetsPostValidator(body).errors match {
+                        case e if e.isEmpty => processValidaddPetRequest(f)((body))(possibleWriters, addPetResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(addPetResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidaddPetRequest[T <: Any](f: addPetActionType)(request: addPetActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusaddPet orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val addPetWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type createUsersWithArrayInputActionRequestType       = (UsersCreateWithListPostBody)
+    private type createUsersWithArrayInputActionType              = createUsersWithArrayInputActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatuscreateUsersWithArrayInput: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+        private def createUsersWithArrayInputParser(maxLength: Int = parse.DefaultMaxTextLength) = optionParser[UsersCreateWithListPostBodyOpt]("application/json", "Invalid UsersCreateWithListPostBody", maxLength)
+
+    def createUsersWithArrayInputAction = (f: createUsersWithArrayInputActionType) => Action(createUsersWithArrayInputParser()) { request =>
+        val createUsersWithArrayInputResponseMimeType    = "application/json"
+
+        val possibleWriters = Map.empty[Int,String => Writeable[Any]].withDefaultValue(anyToWritable[Null])
+        val body = request.body
+        
+
+            val result =
+                    new UsersCreateWithArrayPostValidator(body).errors match {
+                        case e if e.isEmpty => processValidcreateUsersWithArrayInputRequest(f)((body))(possibleWriters, createUsersWithArrayInputResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(createUsersWithArrayInputResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidcreateUsersWithArrayInputRequest[T <: Any](f: createUsersWithArrayInputActionType)(request: createUsersWithArrayInputActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatuscreateUsersWithArrayInput orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val createUsersWithArrayInputWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type getOrderByIdActionRequestType       = (String)
+    private type getOrderByIdActionType              = getOrderByIdActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusgetOrderById: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def getOrderByIdAction = (f: getOrderByIdActionType) => (orderId: String) => Action { 
+        val getOrderByIdResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                404 -> anyToWritable[Null], 
+                400 -> anyToWritable[Null], 
+                200 -> anyToWritable[Order]
+        )
+        
+
+            val result =
+                    new StoresOrderOrderIdGetValidator(orderId).errors match {
+                        case e if e.isEmpty => processValidgetOrderByIdRequest(f)((orderId))(possibleWriters, getOrderByIdResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(getOrderByIdResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidgetOrderByIdRequest[T <: Any](f: getOrderByIdActionType)(request: getOrderByIdActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusgetOrderById orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val getOrderByIdWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type deleteOrderActionRequestType       = (String)
+    private type deleteOrderActionType              = deleteOrderActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusdeleteOrder: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def deleteOrderAction = (f: deleteOrderActionType) => (orderId: String) => Action { 
+        val deleteOrderResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                404 -> anyToWritable[Null], 
+                400 -> anyToWritable[Null]
+        )
+        
+
+            val result =
+                    new StoresOrderOrderIdDeleteValidator(orderId).errors match {
+                        case e if e.isEmpty => processValiddeleteOrderRequest(f)((orderId))(possibleWriters, deleteOrderResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(deleteOrderResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValiddeleteOrderRequest[T <: Any](f: deleteOrderActionType)(request: deleteOrderActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusdeleteOrder orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val deleteOrderWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type logoutUserActionRequestType       = (Unit)
+    private type logoutUserActionType              = logoutUserActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatuslogoutUser: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def logoutUserAction = (f: logoutUserActionType) => Action { 
+        val logoutUserResponseMimeType    = "application/json"
+
+        val possibleWriters = Map.empty[Int,String => Writeable[Any]].withDefaultValue(anyToWritable[Null])
+        
+
+            val result = processValidlogoutUserRequest(f)()(possibleWriters, logoutUserResponseMimeType)
+            result
+
+    }
+
+    private def processValidlogoutUserRequest[T <: Any](f: logoutUserActionType)(request: logoutUserActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatuslogoutUser orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val logoutUserWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type getPetByIdActionRequestType       = (Long)
+    private type getPetByIdActionType              = getPetByIdActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusgetPetById: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def getPetByIdAction = (f: getPetByIdActionType) => (petId: Long) => Action { 
+        val getPetByIdResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                404 -> anyToWritable[Null], 
+                400 -> anyToWritable[Null], 
+                200 -> anyToWritable[Pet]
+        )
+        
+
+            val result =
+                    new PetsPetIdGetValidator(petId).errors match {
+                        case e if e.isEmpty => processValidgetPetByIdRequest(f)((petId))(possibleWriters, getPetByIdResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(getPetByIdResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidgetPetByIdRequest[T <: Any](f: getPetByIdActionType)(request: getPetByIdActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusgetPetById orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val getPetByIdWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type updatePetWithFormActionRequestType       = (String, String, String)
+    private type updatePetWithFormActionType              = updatePetWithFormActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusupdatePetWithForm: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def updatePetWithFormAction = (f: updatePetWithFormActionType) => (petId: String, name: String, status: String) => Action { 
+        val updatePetWithFormResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                405 -> anyToWritable[Null]
+        )
+        
+
+            val result =
+                    new PetsPetIdPostValidator(petId, name, status).errors match {
+                        case e if e.isEmpty => processValidupdatePetWithFormRequest(f)((petId, name, status))(possibleWriters, updatePetWithFormResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(updatePetWithFormResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidupdatePetWithFormRequest[T <: Any](f: updatePetWithFormActionType)(request: updatePetWithFormActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusupdatePetWithForm orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val updatePetWithFormWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type deletePetActionRequestType       = (String, Long)
+    private type deletePetActionType              = deletePetActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusdeletePet: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def deletePetAction = (f: deletePetActionType) => (petId: Long) => Action { request =>
+        val deletePetResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                400 -> anyToWritable[Null]
+        )
+        
+        val api_key =
+            fromHeaders[String]("api_key", request.headers.toMap)
+        
+            (api_key) match {
+                case (Right(api_key)) =>
+
+            val result =
+                    new PetsPetIdDeleteValidator(api_key, petId).errors match {
+                        case e if e.isEmpty => processValiddeletePetRequest(f)((api_key, petId))(possibleWriters, deletePetResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(deletePetResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+            case (_) =>
+                val msg = Seq(api_key).filter{_.isLeft}.map(_.left.get).mkString("\n")
+                BadRequest(msg)
+            }
+
+    }
+
+    private def processValiddeletePetRequest[T <: Any](f: deletePetActionType)(request: deletePetActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusdeletePet orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val deletePetWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type findPetsByStatusActionRequestType       = (PetsFindByStatusGetStatus)
+    private type findPetsByStatusActionType              = findPetsByStatusActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusfindPetsByStatus: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def findPetsByStatusAction = (f: findPetsByStatusActionType) => (status: PetsFindByStatusGetStatus) => Action { 
+        val findPetsByStatusResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                200 -> anyToWritable[Seq[Pet]], 
+                400 -> anyToWritable[Null]
+        )
+        
+
+            val result =
+                    new PetsFindByStatusGetValidator(status).errors match {
+                        case e if e.isEmpty => processValidfindPetsByStatusRequest(f)((status))(possibleWriters, findPetsByStatusResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(findPetsByStatusResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidfindPetsByStatusRequest[T <: Any](f: findPetsByStatusActionType)(request: findPetsByStatusActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusfindPetsByStatus orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val findPetsByStatusWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+    private type loginUserActionRequestType       = (OrderStatus, OrderStatus)
+    private type loginUserActionType              = loginUserActionRequestType => Try[(Int, Any)]
+
+    private val errorToStatusloginUser: PartialFunction[Throwable, Status] = { 
+        case _: java.lang.IllegalArgumentException => Status(405)
+    
+        case _: java.lang.IndexOutOfBoundsException => Status(405)
+     } 
+
+
+    def loginUserAction = (f: loginUserActionType) => (username: OrderStatus, password: OrderStatus) => Action { 
+        val loginUserResponseMimeType    = "application/json"
+
+        val possibleWriters = Map(
+                200 -> anyToWritable[String], 
+                400 -> anyToWritable[Null]
+        )
+        
+
+            val result =
+                    new UsersLoginGetValidator(username, password).errors match {
+                        case e if e.isEmpty => processValidloginUserRequest(f)((username, password))(possibleWriters, loginUserResponseMimeType)
+                        case l =>
+                            implicit val marshaller: Writeable[Seq[ParsingError]] = parsingErrors2Writable(loginUserResponseMimeType)
+                            BadRequest(l)
+                    }
+            result
+
+    }
+
+    private def processValidloginUserRequest[T <: Any](f: loginUserActionType)(request: loginUserActionRequestType)(writers: Map[Int, String => Writeable[T]], mimeType: String) = {
+        val callerResult = f(request)
+        val status = callerResult match {
+            case Failure(error) => (errorToStatusloginUser orElse defaultErrorMapping)(error)
+            case Success((code: Int, result: T @ unchecked)) =>
+                writers.get(code).map { writer =>
+                    implicit val loginUserWritableJson = writer(mimeType)
+                    Status(code)(result)
+                }.getOrElse {
+                    implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+                    Status(500)(new IllegalStateException(s"Response code was not defined in specification: $code"))
+                }
+        case Success(other) =>
+            implicit val errorWriter = anyToWritable[IllegalStateException](mimeType)
+            Status(500)(new IllegalStateException(s"Expected pair (responseCode, response) from the controller, but was: other"))
+        }
+        status
+    }
+}

--- a/compiler/src/test/resources/expected_results/controllers/split.petstore.api.yaml.scala
+++ b/compiler/src/test/resources/expected_results/controllers/split.petstore.api.yaml.scala
@@ -1,0 +1,182 @@
+
+import play.api.mvc.{Action, Controller}
+
+import play.api.data.validation.Constraint
+
+import de.zalando.play.controllers._
+
+import PlayBodyParsing._
+
+import PlayValidations._
+
+import scala.util._
+
+
+
+package split.petstore.api.yaml {
+
+    class SplitPetstoreApiYaml extends SplitPetstoreApiYamlBase {
+        val findPetsByTags = findPetsByTagsAction { (tags: PetsFindByStatusGetStatus) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  findPetsByTagsAction
+        val placeOrder = placeOrderAction { (body: StoresOrderPostBody) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  placeOrderAction
+        val createUser = createUserAction { (body: UsersUsernamePutBody) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  createUserAction
+        val createUsersWithListInput = createUsersWithListInputAction { (body: UsersCreateWithListPostBody) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  createUsersWithListInputAction
+        val getUserByName = getUserByNameAction { (username: String) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  getUserByNameAction
+        val updateUser = updateUserAction { input: (String, UsersUsernamePutBody) =>
+            val (username, body) = input
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  updateUserAction
+        val deleteUser = deleteUserAction { (username: String) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  deleteUserAction
+        val updatePet = updatePetAction { (body: PetsPostBody) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  updatePetAction
+        val addPet = addPetAction { (body: PetsPostBody) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  addPetAction
+        val createUsersWithArrayInput = createUsersWithArrayInputAction { (body: UsersCreateWithListPostBody) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  createUsersWithArrayInputAction
+        val getOrderById = getOrderByIdAction { (orderId: String) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  getOrderByIdAction
+        val deleteOrder = deleteOrderAction { (orderId: String) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  deleteOrderAction
+        val logoutUser = logoutUserAction { _ =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  logoutUserAction
+        val getPetById = getPetByIdAction { (petId: Long) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  getPetByIdAction
+        val updatePetWithForm = updatePetWithFormAction { input: (String, String, String) =>
+            val (petId, name, status) = input
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  updatePetWithFormAction
+        val deletePet = deletePetAction { input: (String, Long) =>
+            val (api_key, petId) = input
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  deletePetAction
+        val findPetsByStatus = findPetsByStatusAction { (status: PetsFindByStatusGetStatus) =>
+            
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  findPetsByStatusAction
+        val loginUser = loginUserAction { input: (OrderStatus, OrderStatus) =>
+            val (username, password) = input
+            
+
+            Failure(???)
+
+            
+
+        } //////// EOF ////////  loginUserAction
+    }
+}

--- a/compiler/src/test/resources/expected_results/flat_types/split.petstore.api.yaml.types
+++ b/compiler/src/test/resources/expected_results/flat_types/split.petstore.api.yaml.types
@@ -1,0 +1,94 @@
+⌿definitions⌿Order⌿status -> 
+	Opt(Str)
+⌿definitions⌿Order⌿petId -> 
+	Opt(Lng)
+⌿definitions⌿Order⌿shipDate -> 
+	Opt(DateTime)
+⌿definitions⌿Order⌿complete -> 
+	Opt(Bool)
+⌿definitions⌿Pet⌿tags -> 
+	Opt(TypeRef(⌿definitions⌿Pet⌿tags⌿Opt))
+⌿definitions⌿Order⌿quantity -> 
+	Opt(Intgr)
+⌿definitions⌿Pet⌿photoUrls -> 
+	ArrResult(Str)
+⌿definitions⌿Pet⌿category -> 
+	Opt(TypeRef(⌿definitions⌿Pet⌿category⌿Opt))
+⌿definitions⌿Pet⌿category⌿Opt -> 
+	TypeDef(⌿definitions⌿Category, Seq(
+		Field(⌿definitions⌿Category⌿id, TypeRef(⌿definitions⌿Order⌿petId)), 
+		Field(⌿definitions⌿Category⌿name, TypeRef(⌿definitions⌿Order⌿status))))
+⌿paths⌿/users/{username}⌿get⌿username -> 
+	Str
+⌿paths⌿/pets⌿post⌿body -> 
+	Opt(TypeRef(⌿paths⌿/pets⌿post⌿body⌿Opt))
+⌿paths⌿/users/{username}⌿put⌿body -> 
+	Opt(TypeRef(⌿paths⌿/users/{username}⌿put⌿body⌿Opt))
+⌿paths⌿/stores/order⌿post⌿body -> 
+	Opt(TypeRef(⌿paths⌿/stores/order⌿post⌿body⌿Opt))
+⌿paths⌿/pets/{petId}⌿delete⌿petId -> 
+	Lng
+⌿paths⌿/users/createWithList⌿post⌿body -> 
+	Opt(TypeRef(⌿paths⌿/users/createWithList⌿post⌿body⌿Opt))
+⌿paths⌿/pets/findByStatus⌿get⌿status -> 
+	Opt(TypeRef(⌿paths⌿/pets/findByStatus⌿get⌿status⌿Opt))
+⌿definitions⌿Pet⌿tags⌿Opt -> 
+	ArrResult(TypeRef(⌿definitions⌿Pet⌿category⌿Opt))
+⌿paths⌿/users/createWithList⌿post⌿responses⌿default -> 
+	Null
+⌿paths⌿/pets/findByStatus⌿get⌿status⌿Opt -> 
+	Arr(Str)
+⌿paths⌿/users/createWithList⌿post⌿body⌿Opt -> 
+	Arr(TypeRef(⌿paths⌿/users/{username}⌿put⌿body⌿Opt))
+⌿paths⌿/pets/findByStatus⌿get⌿responses⌿200 -> 
+	ArrResult(TypeRef(⌿paths⌿/pets⌿post⌿body⌿Opt))
+⌿paths⌿/pets⌿post⌿body⌿Opt -> 
+	TypeDef(⌿definitions⌿Pet, Seq(
+		Field(⌿definitions⌿Pet⌿name, Str), 
+		Field(⌿definitions⌿Pet⌿tags, TypeRef(⌿definitions⌿Pet⌿tags)), 
+		Field(⌿definitions⌿Pet⌿photoUrls, TypeRef(⌿definitions⌿Pet⌿photoUrls)), 
+		Field(⌿definitions⌿Pet⌿id, TypeRef(⌿definitions⌿Order⌿petId)), 
+		Field(⌿definitions⌿Pet⌿status, TypeRef(⌿definitions⌿Order⌿status)), 
+		Field(⌿definitions⌿Pet⌿category, TypeRef(⌿definitions⌿Pet⌿category))))
+⌿paths⌿/users/{username}⌿put⌿body⌿Opt -> 
+	TypeDef(⌿definitions⌿User, Seq(
+		Field(⌿definitions⌿User⌿email, TypeRef(⌿definitions⌿Order⌿status)), 
+		Field(⌿definitions⌿User⌿username, TypeRef(⌿definitions⌿Order⌿status)), 
+		Field(⌿definitions⌿User⌿userStatus, TypeRef(⌿definitions⌿Order⌿quantity)), 
+		Field(⌿definitions⌿User⌿lastName, TypeRef(⌿definitions⌿Order⌿status)), 
+		Field(⌿definitions⌿User⌿firstName, TypeRef(⌿definitions⌿Order⌿status)), 
+		Field(⌿definitions⌿User⌿id, TypeRef(⌿definitions⌿Order⌿petId)), 
+		Field(⌿definitions⌿User⌿phone, TypeRef(⌿definitions⌿Order⌿status)), 
+		Field(⌿definitions⌿User⌿password, TypeRef(⌿definitions⌿Order⌿status))))
+⌿paths⌿/stores/order⌿post⌿body⌿Opt -> 
+	TypeDef(⌿definitions⌿Order, Seq(
+		Field(⌿definitions⌿Order⌿shipDate, TypeRef(⌿definitions⌿Order⌿shipDate)), 
+		Field(⌿definitions⌿Order⌿quantity, TypeRef(⌿definitions⌿Order⌿quantity)), 
+		Field(⌿definitions⌿Order⌿petId, TypeRef(⌿definitions⌿Order⌿petId)), 
+		Field(⌿definitions⌿Order⌿id, TypeRef(⌿definitions⌿Order⌿petId)), 
+		Field(⌿definitions⌿Order⌿complete, TypeRef(⌿definitions⌿Order⌿complete)), 
+		Field(⌿definitions⌿Order⌿status, TypeRef(⌿definitions⌿Order⌿status))))
+-- params --
+
+⌿paths⌿/pets/{petId}⌿get⌿petId -> Parameter(petId,Lng(TypeMeta(Some("int64"), List())),None,None,[^/]+,true,path)
+⌿paths⌿/pets/{petId}⌿post⌿name -> Parameter(name,Str(None,TypeMeta(None, List())),None,None,.+,true,formData)
+⌿paths⌿/pets⌿post⌿body -> Parameter(body,TypeRef(⌿paths⌿/pets⌿post⌿body),None,None,.+,false,body)
+⌿paths⌿/stores/order/{orderId}⌿delete⌿orderId -> Parameter(orderId,Str(None,TypeMeta(None, List())),None,None,[^/]+,true,path)
+⌿paths⌿/pets/{petId}⌿post⌿petId -> Parameter(petId,Str(None,TypeMeta(None, List())),None,None,[^/]+,true,path)
+⌿paths⌿/pets/{petId}⌿delete⌿petId -> Parameter(petId,Lng(TypeMeta(Some("int64"), List())),None,None,[^/]+,true,path)
+⌿paths⌿/users/{username}⌿put⌿body -> Parameter(body,TypeRef(⌿paths⌿/users/{username}⌿put⌿body),None,None,.+,false,body)
+⌿paths⌿/pets/{petId}⌿delete⌿api_key -> Parameter(api_key,Str(None,TypeMeta(None, List())),None,None,.+,false,header)
+⌿paths⌿/pets⌿put⌿body -> Parameter(body,TypeRef(⌿paths⌿/pets⌿post⌿body),None,None,.+,false,body)
+⌿paths⌿/users/{username}⌿put⌿username -> Parameter(username,Str(None,TypeMeta(None, List())),None,None,[^/]+,true,path)
+⌿paths⌿/users/createWithList⌿post⌿body -> Parameter(body,TypeRef(⌿paths⌿/users/createWithList⌿post⌿body),None,None,.+,false,body)
+⌿paths⌿/users/{username}⌿get⌿username -> Parameter(username,Str(None,TypeMeta(None, List())),None,None,[^/]+,true,path)
+⌿paths⌿/users/{username}⌿delete⌿username -> Parameter(username,Str(None,TypeMeta(None, List())),None,None,[^/]+,true,path)
+⌿paths⌿/users/login⌿get⌿password -> Parameter(password,TypeRef(⌿definitions⌿Order⌿status),None,None,.+,true,query)
+⌿paths⌿/stores/order⌿post⌿body -> Parameter(body,TypeRef(⌿paths⌿/stores/order⌿post⌿body),None,None,.+,false,body)
+⌿paths⌿/users/createWithArray⌿post⌿body -> Parameter(body,TypeRef(⌿paths⌿/users/createWithList⌿post⌿body),None,None,.+,false,body)
+⌿paths⌿/users⌿post⌿body -> Parameter(body,TypeRef(⌿paths⌿/users/{username}⌿put⌿body),None,None,.+,false,body)
+⌿paths⌿/pets/findByStatus⌿get⌿status -> Parameter(status,TypeRef(⌿paths⌿/pets/findByStatus⌿get⌿status),None,None,.+,true,query)
+⌿paths⌿/users/login⌿get⌿username -> Parameter(username,TypeRef(⌿definitions⌿Order⌿status),None,None,.+,true,query)
+⌿paths⌿/pets/{petId}⌿post⌿status -> Parameter(status,Str(None,TypeMeta(None, List())),None,None,.+,true,formData)
+⌿paths⌿/pets/findByTags⌿get⌿tags -> Parameter(tags,TypeRef(⌿paths⌿/pets/findByStatus⌿get⌿status),None,None,.+,true,query)
+⌿paths⌿/stores/order/{orderId}⌿get⌿orderId -> Parameter(orderId,Str(None,TypeMeta(None, List())),None,None,[^/]+,true,path)

--- a/compiler/src/test/resources/expected_results/model/instagram.api.yaml.scala
+++ b/compiler/src/test/resources/expected_results/model/instagram.api.yaml.scala
@@ -1,132 +1,77 @@
 package instagram.api
+
 package object yaml {
-import de.zalando.play.controllers.PlayPathBindables
-type TagsSearchGetResponses200Meta = Option[UsersSelfRequested_byGetResponses200MetaOpt]
 
+
+    import de.zalando.play.controllers.PlayPathBindables
+
+
+
+    type TagsSearchGetResponses200Meta = Option[UsersSelfRequested_byGetResponses200MetaOpt]
     type LocationsLocation_idLocation_id = Int
-
     type MediaMedia_idGetResponses200VideosStandard_resolution = Option[Image]
-
     type MediaFilter = Option[String]
-
     type MediaMedia_idCommentsDeleteResponses200Meta = Option[MediaMedia_idLikesGetResponses200MetaOpt]
-
     type UsersSelfFeedGetResponses200Data = Option[UsersSelfFeedGetResponses200DataOpt]
-
     type MediaTags = Option[MediaTagsOpt]
-
     type MediaMedia_idLikesGetResponses200Data = Option[MediaMedia_idLikesGetResponses200DataOpt]
-
     type MediaId = Option[Int]
-
     type MediaTagsOpt = Seq[Tag]
-
     type MediaImages = Option[MediaImagesOpt]
-
     type MediaLikes = Option[MediaLikesOpt]
-
     type MediaMedia_idCommentsGetResponses200DataOpt = Seq[Comment]
-
     type MediaUsers_in_photoOpt = Seq[MiniProfile]
-
     type MediaMedia_idLikesGetResponses200DataOpt = Seq[Like]
-
     type LocationsSearchGetResponses200Data = Option[LocationsSearchGetResponses200DataOpt]
-
     type MediaComments_esc = Option[MediaComments_Opt]
-
     type MediaSearchGetResponses200DataOpt = Seq[MediaSearchGetResponses200DataOptArrResult]
-
     type CommentFrom = Option[MiniProfile]
-
     type LocationsSearchGetResponses200DataOpt = Seq[Location]
-
     type MediaSearchGetResponses200Data = Option[MediaSearchGetResponses200DataOpt]
-
     type UsersSelfFeedGetResponses200DataOpt = Seq[Media]
-
     type UsersUser_idGetResponses200Data = Option[User]
-
     type MediaVideos = Option[MediaVideosOpt]
-
     type MediaLocation = Option[Location]
-
     type GeographiesGeo_idMediaRecentGetResponses200 = Null
-
     type MediaUsers_in_photo = Option[MediaUsers_in_photoOpt]
-
     type LocationLatitude = Option[Double]
-
     type MediaMedia_idCommentsGetResponses200Data = Option[MediaMedia_idCommentsGetResponses200DataOpt]
-
     type User_id_paramUser_id = Double
-
     type UserCounts = Option[UserCountsOpt]
-
     type Tag_nameTag_name = String
 
+
     case class UsersSelfFeedGetResponses200(data: UsersSelfFeedGetResponses200Data) 
-
-    case class MediaMedia_idCommentsDeleteResponses200(meta: MediaMedia_idCommentsDeleteResponses200Meta, data: MediaFilter)
-
-    case class MediaSearchGetResponses200DataOptArrResult(location: MediaLocation, created_time: MediaId, comments_esc: MediaComments_esc, tags: MediaTags, users_in_photo: MediaUsers_in_photo, filter: MediaFilter, likes: MediaLikes, id: MediaId, videos: MediaVideos, `type`: MediaFilter, images: MediaImages, user: CommentFrom, distance: LocationLatitude)
-
-    case class UsersUser_idFollowsGetResponses200(data: MediaUsers_in_photo)
-
+    case class MediaMedia_idCommentsDeleteResponses200(meta: MediaMedia_idCommentsDeleteResponses200Meta, data: MediaFilter) 
+    case class MediaSearchGetResponses200DataOptArrResult(location: MediaLocation, created_time: MediaId, comments_esc: MediaComments_esc, tags: MediaTags, users_in_photo: MediaUsers_in_photo, filter: MediaFilter, likes: MediaLikes, id: MediaId, videos: MediaVideos, `type`: MediaFilter, images: MediaImages, user: CommentFrom, distance: LocationLatitude) 
+    case class UsersUser_idFollowsGetResponses200(data: MediaUsers_in_photo) 
     case class UserCountsOpt(media: MediaId, follows: MediaId, follwed_by: MediaId) 
-
     case class User(website: MediaFilter, profile_picture: MediaFilter, username: MediaFilter, full_name: MediaFilter, bio: MediaFilter, id: MediaId, counts: UserCounts) 
-
-    case class TagsTag_nameMediaRecentGetResponses200(data: MediaTags)
-
+    case class TagsTag_nameMediaRecentGetResponses200(data: MediaTags) 
     case class Image(width: MediaId, height: MediaId, url: MediaFilter) 
-
-    case class UsersSelfRequested_byGetResponses200(meta: TagsSearchGetResponses200Meta, data: MediaUsers_in_photo)
-
+    case class UsersSelfRequested_byGetResponses200(meta: TagsSearchGetResponses200Meta, data: MediaUsers_in_photo) 
     case class Tag(media_count: MediaId, name: MediaFilter) 
-
-    case class UsersSelfRequested_byGetResponses200MetaOpt(code: MediaId)
-
-    case class LocationsLocation_idGetResponses200(data: MediaLocation)
-
+    case class UsersSelfRequested_byGetResponses200MetaOpt(code: MediaId) 
+    case class LocationsLocation_idGetResponses200(data: MediaLocation) 
     case class Comment(id: MediaFilter, created_time: MediaFilter, text: MediaFilter, from: CommentFrom) 
-
-    case class Media(location: MediaLocation, created_time: MediaId, comments_esc: MediaComments_esc, tags: MediaTags, users_in_photo: MediaUsers_in_photo, filter: MediaFilter, likes: MediaLikes, id: MediaId, videos: MediaVideos, `type`: MediaFilter, images: MediaImages, user: CommentFrom)
-
-    case class MediaMedia_idLikesGetResponses200(meta: MediaMedia_idCommentsDeleteResponses200Meta, data: MediaMedia_idLikesGetResponses200Data)
-
-    case class MediaMedia_idLikesGetResponses200MetaOpt(code: LocationLatitude)
-
+    case class Media(location: MediaLocation, created_time: MediaId, comments_esc: MediaComments_esc, tags: MediaTags, users_in_photo: MediaUsers_in_photo, filter: MediaFilter, likes: MediaLikes, id: MediaId, videos: MediaVideos, `type`: MediaFilter, images: MediaImages, user: CommentFrom) 
+    case class MediaMedia_idLikesGetResponses200(meta: MediaMedia_idCommentsDeleteResponses200Meta, data: MediaMedia_idLikesGetResponses200Data) 
+    case class MediaMedia_idLikesGetResponses200MetaOpt(code: LocationLatitude) 
     case class MediaSearchGetResponses200(data: MediaSearchGetResponses200Data) 
-
     case class TagsSearchGetResponses200(meta: TagsSearchGetResponses200Meta, data: MediaTags) 
-
-    case class Like(first_name: MediaFilter, id: MediaFilter, last_name: MediaFilter, `type`: MediaFilter, user_name: MediaFilter)
-
-    case class MediaComments_Opt(count: MediaId, data: MediaMedia_idCommentsGetResponses200Data)
-
-    case class UsersUser_idGetResponses200(data: UsersUser_idGetResponses200Data)
-
-    case class MediaMedia_idCommentsGetResponses200(meta: MediaMedia_idCommentsDeleteResponses200Meta, data: MediaMedia_idCommentsGetResponses200Data)
-
-    case class MediaVideosOpt(low_resolution: MediaMedia_idGetResponses200VideosStandard_resolution, standard_resolution: MediaMedia_idGetResponses200VideosStandard_resolution)
-
+    case class Like(first_name: MediaFilter, id: MediaFilter, last_name: MediaFilter, `type`: MediaFilter, user_name: MediaFilter) 
+    case class MediaComments_Opt(count: MediaId, data: MediaMedia_idCommentsGetResponses200Data) 
+    case class UsersUser_idGetResponses200(data: UsersUser_idGetResponses200Data) 
+    case class MediaMedia_idCommentsGetResponses200(meta: MediaMedia_idCommentsDeleteResponses200Meta, data: MediaMedia_idCommentsGetResponses200Data) 
+    case class MediaVideosOpt(low_resolution: MediaMedia_idGetResponses200VideosStandard_resolution, standard_resolution: MediaMedia_idGetResponses200VideosStandard_resolution) 
     case class Location(id: MediaFilter, name: MediaFilter, latitude: LocationLatitude, longitude: LocationLatitude) 
-
     case class MiniProfile(user_name: MediaFilter, full_name: MediaFilter, id: MediaId, profile_picture: MediaFilter) 
-
     case class MediaLikesOpt(count: MediaId, data: MediaUsers_in_photo) 
-
     case class LocationsSearchGetResponses200(data: LocationsSearchGetResponses200Data) 
+    case class MediaImagesOpt(low_resolution: MediaMedia_idGetResponses200VideosStandard_resolution, thumbnail: MediaMedia_idGetResponses200VideosStandard_resolution, standard_resolution: MediaMedia_idGetResponses200VideosStandard_resolution) 
 
-    case class MediaImagesOpt(low_resolution: MediaMedia_idGetResponses200VideosStandard_resolution, thumbnail: MediaMedia_idGetResponses200VideosStandard_resolution, standard_resolution: MediaMedia_idGetResponses200VideosStandard_resolution)
-
-    
-
-
-    
-    
     implicit val bindable_OptionIntQuery = PlayPathBindables.createOptionQueryBindable[Int]
     implicit val bindable_OptionDoubleQuery = PlayPathBindables.createOptionQueryBindable[Double]
     implicit val bindable_OptionStringQuery = PlayPathBindables.createOptionQueryBindable[String]
-    }
+
+}

--- a/compiler/src/test/resources/expected_results/model/split.petstore.api.yaml.scala
+++ b/compiler/src/test/resources/expected_results/model/split.petstore.api.yaml.scala
@@ -1,0 +1,43 @@
+package split.petstore.api
+
+package object yaml {
+
+    import de.zalando.play.controllers.ArrayWrapper
+    import org.joda.time.DateTime
+
+    import de.zalando.play.controllers.PlayPathBindables
+
+
+
+    type UsersUsernameGetUsername = String
+    type UsersCreateWithListPostResponsesDefault = Null
+    type OrderStatus = Option[String]
+    type PetsFindByStatusGetStatusOpt = ArrayWrapper[String]
+    type UsersCreateWithListPostBodyOpt = ArrayWrapper[User]
+    type OrderPetId = Option[Long]
+    type PetsFindByStatusGetResponses200 = Seq[Pet]
+    type PetsPostBody = Option[Pet]
+    type OrderShipDate = Option[DateTime]
+    type UsersUsernamePutBody = Option[User]
+    type StoresOrderPostBody = Option[Order]
+    type OrderComplete = Option[Boolean]
+    type PetTags = Option[PetTagsOpt]
+    type PetsPetIdDeletePetId = Long
+    type OrderQuantity = Option[Int]
+    type PetPhotoUrls = Seq[String]
+    type UsersCreateWithListPostBody = Option[UsersCreateWithListPostBodyOpt]
+    type PetsFindByStatusGetStatus = Option[PetsFindByStatusGetStatusOpt]
+    type PetCategory = Option[PetCategoryOpt]
+    type PetTagsOpt = Seq[PetCategoryOpt]
+
+
+    case class PetCategoryOpt(id: OrderPetId, name: OrderStatus) 
+    case class Pet(name: String, tags: PetTags, photoUrls: PetPhotoUrls, id: OrderPetId, status: OrderStatus, category: PetCategory) 
+    case class User(email: OrderStatus, username: OrderStatus, userStatus: OrderQuantity, lastName: OrderStatus, firstName: OrderStatus, id: OrderPetId, phone: OrderStatus, password: OrderStatus) 
+    case class Order(shipDate: OrderShipDate, quantity: OrderQuantity, petId: OrderPetId, id: OrderPetId, complete: OrderComplete, status: OrderStatus) 
+
+    implicit val bindable_OptionStringQuery = PlayPathBindables.createOptionQueryBindable[String]
+    implicit val bindable_ArrayWrapperStringQuery = PlayPathBindables.createArrayWrapperQueryBindable[String]("multi")
+    implicit val bindable_OptionPetsFindByStatusGetStatusOptQuery = PlayPathBindables.createOptionQueryBindable[PetsFindByStatusGetStatusOpt]
+
+}

--- a/compiler/src/test/resources/expected_results/test_data/split.petstore.api.yaml.scala
+++ b/compiler/src/test/resources/expected_results/test_data/split.petstore.api.yaml.scala
@@ -1,0 +1,106 @@
+package split.petstore.api.yaml
+
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary
+import Arbitrary._
+import de.zalando.play.controllers.ArrayWrapper
+import org.joda.time.DateTime
+
+object Generators {
+    
+
+    
+    def createStringGenerator = _generate(StringGenerator)
+    def createNullGenerator = _generate(NullGenerator)
+    def createOrderStatusGenerator = _generate(OrderStatusGenerator)
+    def createPetsFindByStatusGetStatusOptGenerator = _generate(PetsFindByStatusGetStatusOptGenerator)
+    def createUsersCreateWithListPostBodyOptGenerator = _generate(UsersCreateWithListPostBodyOptGenerator)
+    def createOrderPetIdGenerator = _generate(OrderPetIdGenerator)
+    def createPetsFindByStatusGetResponses200Generator = _generate(PetsFindByStatusGetResponses200Generator)
+    def createPetsPostBodyGenerator = _generate(PetsPostBodyGenerator)
+    def createOrderShipDateGenerator = _generate(OrderShipDateGenerator)
+    def createUsersUsernamePutBodyGenerator = _generate(UsersUsernamePutBodyGenerator)
+    def createStoresOrderPostBodyGenerator = _generate(StoresOrderPostBodyGenerator)
+    def createOrderCompleteGenerator = _generate(OrderCompleteGenerator)
+    def createPetTagsGenerator = _generate(PetTagsGenerator)
+    def createLongGenerator = _generate(LongGenerator)
+    def createOrderQuantityGenerator = _generate(OrderQuantityGenerator)
+    def createPetPhotoUrlsGenerator = _generate(PetPhotoUrlsGenerator)
+    def createUsersCreateWithListPostBodyGenerator = _generate(UsersCreateWithListPostBodyGenerator)
+    def createPetsFindByStatusGetStatusGenerator = _generate(PetsFindByStatusGetStatusGenerator)
+    def createPetCategoryGenerator = _generate(PetCategoryGenerator)
+    def createPetTagsOptGenerator = _generate(PetTagsOptGenerator)
+    
+
+    
+    def StringGenerator = arbitrary[String]
+    def NullGenerator = arbitrary[Null]
+    def OrderStatusGenerator = Gen.option(arbitrary[String])
+    def PetsFindByStatusGetStatusOptGenerator = _genList(arbitrary[String], "multi")
+    def UsersCreateWithListPostBodyOptGenerator = _genList(UserGenerator, "csv")
+    def OrderPetIdGenerator = Gen.option(arbitrary[Long])
+    def PetsFindByStatusGetResponses200Generator = Gen.containerOf[List,Pet](PetGenerator)
+    def PetsPostBodyGenerator = Gen.option(PetGenerator)
+    def OrderShipDateGenerator = Gen.option(arbitrary[DateTime])
+    def UsersUsernamePutBodyGenerator = Gen.option(UserGenerator)
+    def StoresOrderPostBodyGenerator = Gen.option(OrderGenerator)
+    def OrderCompleteGenerator = Gen.option(arbitrary[Boolean])
+    def PetTagsGenerator = Gen.option(PetTagsOptGenerator)
+    def LongGenerator = arbitrary[Long]
+    def OrderQuantityGenerator = Gen.option(arbitrary[Int])
+    def PetPhotoUrlsGenerator = Gen.containerOf[List,String](arbitrary[String])
+    def UsersCreateWithListPostBodyGenerator = Gen.option(UsersCreateWithListPostBodyOptGenerator)
+    def PetsFindByStatusGetStatusGenerator = Gen.option(PetsFindByStatusGetStatusOptGenerator)
+    def PetCategoryGenerator = Gen.option(PetCategoryOptGenerator)
+    def PetTagsOptGenerator = Gen.containerOf[List,PetCategoryOpt](PetCategoryOptGenerator)
+    
+
+    def createPetCategoryOptGenerator = _generate(PetCategoryOptGenerator)
+    def createPetGenerator = _generate(PetGenerator)
+    def createUserGenerator = _generate(UserGenerator)
+    def createOrderGenerator = _generate(OrderGenerator)
+
+
+    def PetCategoryOptGenerator = for {
+        id <- OrderPetIdGenerator
+        name <- OrderStatusGenerator
+    } yield PetCategoryOpt(id, name)
+    def PetGenerator = for {
+        name <- arbitrary[String]
+        tags <- PetTagsGenerator
+        photoUrls <- PetPhotoUrlsGenerator
+        id <- OrderPetIdGenerator
+        status <- OrderStatusGenerator
+        category <- PetCategoryGenerator
+    } yield Pet(name, tags, photoUrls, id, status, category)
+    def UserGenerator = for {
+        email <- OrderStatusGenerator
+        username <- OrderStatusGenerator
+        userStatus <- OrderQuantityGenerator
+        lastName <- OrderStatusGenerator
+        firstName <- OrderStatusGenerator
+        id <- OrderPetIdGenerator
+        phone <- OrderStatusGenerator
+        password <- OrderStatusGenerator
+    } yield User(email, username, userStatus, lastName, firstName, id, phone, password)
+    def OrderGenerator = for {
+        shipDate <- OrderShipDateGenerator
+        quantity <- OrderQuantityGenerator
+        petId <- OrderPetIdGenerator
+        id <- OrderPetIdGenerator
+        complete <- OrderCompleteGenerator
+        status <- OrderStatusGenerator
+    } yield Order(shipDate, quantity, petId, id, complete, status)
+
+    def _generate[T](gen: Gen[T]) = (count: Int) => for (i <- 1 to count) yield gen.sample
+
+    def _genList[T](gen: Gen[T], format: String): Gen[ArrayWrapper[T]] = for {
+        items <- Gen.containerOf[List,T](gen)
+    } yield ArrayWrapper(format)(items)
+    
+    
+    implicit lazy val arbDateTime: Arbitrary[DateTime] = Arbitrary(for {
+        l <- arbitrary[Long]
+    } yield new DateTime(System.currentTimeMillis + l))
+    
+}

--- a/compiler/src/test/resources/expected_results/tests/split.petstore.api.yaml.scala
+++ b/compiler/src/test/resources/expected_results/tests/split.petstore.api.yaml.scala
@@ -1,0 +1,1144 @@
+package split.petstore.api.yaml
+
+import de.zalando.play.controllers.PlayBodyParsing
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop._
+import org.scalacheck.Test._
+import org.specs2.mutable._
+import play.api.test.Helpers._
+import play.api.test._
+import play.api.mvc.{QueryStringBindable, PathBindable}
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import java.net.URLEncoder
+import play.api.http.Writeable
+
+import play.api.test.Helpers.{status => requestStatusCode_}
+import play.api.test.Helpers.{contentAsString => requestContentAsString_}
+import play.api.test.Helpers.{contentType => requestContentType_}
+
+import Generators._
+
+    @RunWith(classOf[JUnitRunner])
+    class SplitPetstoreApiYamlSpec extends Specification {
+        def toPath[T](value: T)(implicit binder: PathBindable[T]): String = Option(binder.unbind("", value)).getOrElse("")
+        def toQuery[T](key: String, value: T)(implicit binder: QueryStringBindable[T]): String = Option(binder.unbind(key, value)).getOrElse("")
+        def toHeader[T](value: T)(implicit binder: PathBindable[T]): String = Option(binder.unbind("", value)).getOrElse("")
+
+      def checkResult(props: Prop) =
+        Test.check(Test.Parameters.default, props).status match {
+          case Failed(_, labels) => failure(labels.mkString("\n"))
+          case Proved(_) | Exhausted | Passed => success
+          case PropException(_, e, labels) =>
+            val error = if (labels.isEmpty) e.getLocalizedMessage() else labels.mkString("\n")
+            failure(error)
+        }
+
+      private def parserConstructor(mimeType: String) = PlayBodyParsing.jacksonMapper(mimeType)
+
+      def parseResponseContent[T](content: String, mimeType: Option[String], expectedType: Class[T]) =
+        parserConstructor(mimeType.getOrElse("application/json")).readValue(content, expectedType)
+
+
+    "POST /v2/users" should {
+        def testInvalidInput(body: UsersUsernamePutBody) = {
+
+
+            val url = s"""/v2/users"""
+            val headers = Seq()
+                val parsed_body = PlayBodyParsing.jacksonMapper("application/json").writeValueAsString(body)
+
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new UsersPostValidator(body).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(body: UsersUsernamePutBody) = {
+            
+            val parsed_body = parserConstructor("application/json").writeValueAsString(body)
+            
+            val url = s"""/v2/users"""
+            val headers = Seq()
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new UsersPostValidator(body).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    body <- UsersUsernamePutBodyGenerator
+                } yield body
+            val inputs = genInputs suchThat { body =>
+                new UsersPostValidator(body).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                body <- UsersUsernamePutBodyGenerator
+            } yield body
+            val inputs = genInputs suchThat { body =>
+                new UsersPostValidator(body).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "POST /v2/pets" should {
+        def testInvalidInput(body: PetsPostBody) = {
+
+
+            val url = s"""/v2/pets"""
+            val headers = Seq()
+                val parsed_body = PlayBodyParsing.jacksonMapper("application/json").writeValueAsString(body)
+
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new PetsPostValidator(body).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(body: PetsPostBody) = {
+            
+            val parsed_body = parserConstructor("application/json").writeValueAsString(body)
+            
+            val url = s"""/v2/pets"""
+            val headers = Seq()
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new PetsPostValidator(body).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    body <- PetsPostBodyGenerator
+                } yield body
+            val inputs = genInputs suchThat { body =>
+                new PetsPostValidator(body).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                body <- PetsPostBodyGenerator
+            } yield body
+            val inputs = genInputs suchThat { body =>
+                new PetsPostValidator(body).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "PUT /v2/pets" should {
+        def testInvalidInput(body: PetsPostBody) = {
+
+
+            val url = s"""/v2/pets"""
+            val headers = Seq()
+                val parsed_body = PlayBodyParsing.jacksonMapper("application/json").writeValueAsString(body)
+
+            val path = route(FakeRequest(PUT, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new PetsPutValidator(body).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(body: PetsPostBody) = {
+            
+            val parsed_body = parserConstructor("application/json").writeValueAsString(body)
+            
+            val url = s"""/v2/pets"""
+            val headers = Seq()
+            val path = route(FakeRequest(PUT, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new PetsPutValidator(body).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    body <- PetsPostBodyGenerator
+                } yield body
+            val inputs = genInputs suchThat { body =>
+                new PetsPutValidator(body).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                body <- PetsPostBodyGenerator
+            } yield body
+            val inputs = genInputs suchThat { body =>
+                new PetsPutValidator(body).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "GET /v2/pets/findByStatus" should {
+        def testInvalidInput(status: PetsFindByStatusGetStatus) = {
+
+
+            val url = s"""/v2/pets/findByStatus?${toQuery("status", status)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new PetsFindByStatusGetValidator(status).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(status: PetsFindByStatusGetStatus) = {
+            
+            val url = s"""/v2/pets/findByStatus?${toQuery("status", status)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new PetsFindByStatusGetValidator(status).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    status <- PetsFindByStatusGetStatusGenerator
+                } yield status
+            val inputs = genInputs suchThat { status =>
+                new PetsFindByStatusGetValidator(status).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                status <- PetsFindByStatusGetStatusGenerator
+            } yield status
+            val inputs = genInputs suchThat { status =>
+                new PetsFindByStatusGetValidator(status).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "POST /v2/stores/order" should {
+        def testInvalidInput(body: StoresOrderPostBody) = {
+
+
+            val url = s"""/v2/stores/order"""
+            val headers = Seq()
+                val parsed_body = PlayBodyParsing.jacksonMapper("application/json").writeValueAsString(body)
+
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new StoresOrderPostValidator(body).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(body: StoresOrderPostBody) = {
+            
+            val parsed_body = parserConstructor("application/json").writeValueAsString(body)
+            
+            val url = s"""/v2/stores/order"""
+            val headers = Seq()
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new StoresOrderPostValidator(body).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    body <- StoresOrderPostBodyGenerator
+                } yield body
+            val inputs = genInputs suchThat { body =>
+                new StoresOrderPostValidator(body).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                body <- StoresOrderPostBodyGenerator
+            } yield body
+            val inputs = genInputs suchThat { body =>
+                new StoresOrderPostValidator(body).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "POST /v2/users/createWithArray" should {
+        def testInvalidInput(body: UsersCreateWithListPostBody) = {
+
+
+            val url = s"""/v2/users/createWithArray"""
+            val headers = Seq()
+                val parsed_body = PlayBodyParsing.jacksonMapper("application/json").writeValueAsString(body)
+
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new UsersCreateWithArrayPostValidator(body).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(body: UsersCreateWithListPostBody) = {
+            
+            val parsed_body = parserConstructor("application/json").writeValueAsString(body)
+            
+            val url = s"""/v2/users/createWithArray"""
+            val headers = Seq()
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new UsersCreateWithArrayPostValidator(body).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    body <- UsersCreateWithListPostBodyGenerator
+                } yield body
+            val inputs = genInputs suchThat { body =>
+                new UsersCreateWithArrayPostValidator(body).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                body <- UsersCreateWithListPostBodyGenerator
+            } yield body
+            val inputs = genInputs suchThat { body =>
+                new UsersCreateWithArrayPostValidator(body).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "GET /v2/users/login" should {
+        def testInvalidInput(input: (OrderStatus, OrderStatus)) = {
+
+            val (username, password) = input
+
+            val url = s"""/v2/users/login?${toQuery("username", username)}&${toQuery("password", password)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new UsersLoginGetValidator(username, password).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(input: (OrderStatus, OrderStatus)) = {
+            val (username, password) = input
+            
+            val url = s"""/v2/users/login?${toQuery("username", username)}&${toQuery("password", password)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new UsersLoginGetValidator(username, password).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                        username <- OrderStatusGenerator
+                        password <- OrderStatusGenerator
+                    
+                } yield (username, password)
+            val inputs = genInputs suchThat { case (username, password) =>
+                new UsersLoginGetValidator(username, password).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                    username <- OrderStatusGenerator
+                    password <- OrderStatusGenerator
+                
+            } yield (username, password)
+            val inputs = genInputs suchThat { case (username, password) =>
+                new UsersLoginGetValidator(username, password).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "GET /v2/stores/order/{orderId}" should {
+        def testInvalidInput(orderId: String) = {
+
+
+            val url = s"""/v2/stores/order/${toPath(orderId)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new StoresOrderOrderIdGetValidator(orderId).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(orderId: String) = {
+            
+            val url = s"""/v2/stores/order/${toPath(orderId)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new StoresOrderOrderIdGetValidator(orderId).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    orderId <- StringGenerator
+                } yield orderId
+            val inputs = genInputs suchThat { orderId =>
+                new StoresOrderOrderIdGetValidator(orderId).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                orderId <- StringGenerator
+            } yield orderId
+            val inputs = genInputs suchThat { orderId =>
+                new StoresOrderOrderIdGetValidator(orderId).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "GET /v2/pets/{petId}" should {
+        def testInvalidInput(petId: Long) = {
+
+
+            val url = s"""/v2/pets/${toPath(petId)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new PetsPetIdGetValidator(petId).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(petId: Long) = {
+            
+            val url = s"""/v2/pets/${toPath(petId)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new PetsPetIdGetValidator(petId).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    petId <- LongGenerator
+                } yield petId
+            val inputs = genInputs suchThat { petId =>
+                new PetsPetIdGetValidator(petId).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                petId <- LongGenerator
+            } yield petId
+            val inputs = genInputs suchThat { petId =>
+                new PetsPetIdGetValidator(petId).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "GET /v2/users/{username}" should {
+        def testInvalidInput(username: String) = {
+
+
+            val url = s"""/v2/users/${toPath(username)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new UsersUsernameGetValidator(username).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(username: String) = {
+            
+            val url = s"""/v2/users/${toPath(username)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new UsersUsernameGetValidator(username).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    username <- StringGenerator
+                } yield username
+            val inputs = genInputs suchThat { username =>
+                new UsersUsernameGetValidator(username).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                username <- StringGenerator
+            } yield username
+            val inputs = genInputs suchThat { username =>
+                new UsersUsernameGetValidator(username).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "POST /v2/users/createWithList" should {
+        def testInvalidInput(body: UsersCreateWithListPostBody) = {
+
+
+            val url = s"""/v2/users/createWithList"""
+            val headers = Seq()
+                val parsed_body = PlayBodyParsing.jacksonMapper("application/json").writeValueAsString(body)
+
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new UsersCreateWithListPostValidator(body).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(body: UsersCreateWithListPostBody) = {
+            
+            val parsed_body = parserConstructor("application/json").writeValueAsString(body)
+            
+            val url = s"""/v2/users/createWithList"""
+            val headers = Seq()
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new UsersCreateWithListPostValidator(body).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    body <- UsersCreateWithListPostBodyGenerator
+                } yield body
+            val inputs = genInputs suchThat { body =>
+                new UsersCreateWithListPostValidator(body).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                body <- UsersCreateWithListPostBodyGenerator
+            } yield body
+            val inputs = genInputs suchThat { body =>
+                new UsersCreateWithListPostValidator(body).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "POST /v2/pets/{petId}" should {
+        def testInvalidInput(input: (String, String, String)) = {
+
+            val (petId, name, status) = input
+
+            val url = s"""/v2/pets/${toPath(petId)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*)).get
+            val errors = new PetsPetIdPostValidator(petId, name, status).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(input: (String, String, String)) = {
+            val (petId, name, status) = input
+            
+            val url = s"""/v2/pets/${toPath(petId)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(POST, url).withHeaders(headers:_*)).get
+            val errors = new PetsPetIdPostValidator(petId, name, status).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                        petId <- StringGenerator
+                        name <- StringGenerator
+                        status <- StringGenerator
+                    
+                } yield (petId, name, status)
+            val inputs = genInputs suchThat { case (petId, name, status) =>
+                new PetsPetIdPostValidator(petId, name, status).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                    petId <- StringGenerator
+                    name <- StringGenerator
+                    status <- StringGenerator
+                
+            } yield (petId, name, status)
+            val inputs = genInputs suchThat { case (petId, name, status) =>
+                new PetsPetIdPostValidator(petId, name, status).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "DELETE /v2/users/{username}" should {
+        def testInvalidInput(username: String) = {
+
+
+            val url = s"""/v2/users/${toPath(username)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(DELETE, url).withHeaders(headers:_*)).get
+            val errors = new UsersUsernameDeleteValidator(username).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(username: String) = {
+            
+            val url = s"""/v2/users/${toPath(username)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(DELETE, url).withHeaders(headers:_*)).get
+            val errors = new UsersUsernameDeleteValidator(username).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    username <- StringGenerator
+                } yield username
+            val inputs = genInputs suchThat { username =>
+                new UsersUsernameDeleteValidator(username).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                username <- StringGenerator
+            } yield username
+            val inputs = genInputs suchThat { username =>
+                new UsersUsernameDeleteValidator(username).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "DELETE /v2/stores/order/{orderId}" should {
+        def testInvalidInput(orderId: String) = {
+
+
+            val url = s"""/v2/stores/order/${toPath(orderId)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(DELETE, url).withHeaders(headers:_*)).get
+            val errors = new StoresOrderOrderIdDeleteValidator(orderId).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(orderId: String) = {
+            
+            val url = s"""/v2/stores/order/${toPath(orderId)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(DELETE, url).withHeaders(headers:_*)).get
+            val errors = new StoresOrderOrderIdDeleteValidator(orderId).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    orderId <- StringGenerator
+                } yield orderId
+            val inputs = genInputs suchThat { orderId =>
+                new StoresOrderOrderIdDeleteValidator(orderId).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                orderId <- StringGenerator
+            } yield orderId
+            val inputs = genInputs suchThat { orderId =>
+                new StoresOrderOrderIdDeleteValidator(orderId).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "DELETE /v2/pets/{petId}" should {
+        def testInvalidInput(input: (String, Long)) = {
+
+            val (api_key, petId) = input
+
+            val url = s"""/v2/pets/${toPath(petId)}"""
+            val headers = Seq("api_key" -> toHeader(api_key))
+
+            val path = route(FakeRequest(DELETE, url).withHeaders(headers:_*)).get
+            val errors = new PetsPetIdDeleteValidator(api_key, petId).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(input: (String, Long)) = {
+            val (api_key, petId) = input
+            
+            val url = s"""/v2/pets/${toPath(petId)}"""
+            val headers = Seq("api_key" -> toHeader(api_key))
+            val path = route(FakeRequest(DELETE, url).withHeaders(headers:_*)).get
+            val errors = new PetsPetIdDeleteValidator(api_key, petId).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                        api_key <- StringGenerator
+                        petId <- LongGenerator
+                    
+                } yield (api_key, petId)
+            val inputs = genInputs suchThat { case (api_key, petId) =>
+                new PetsPetIdDeleteValidator(api_key, petId).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                    api_key <- StringGenerator
+                    petId <- LongGenerator
+                
+            } yield (api_key, petId)
+            val inputs = genInputs suchThat { case (api_key, petId) =>
+                new PetsPetIdDeleteValidator(api_key, petId).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "GET /v2/pets/findByTags" should {
+        def testInvalidInput(tags: PetsFindByStatusGetStatus) = {
+
+
+            val url = s"""/v2/pets/findByTags?${toQuery("tags", tags)}"""
+            val headers = Seq()
+
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new PetsFindByTagsGetValidator(tags).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" ) |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(tags: PetsFindByStatusGetStatus) = {
+            
+            val url = s"""/v2/pets/findByTags?${toQuery("tags", tags)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(GET, url).withHeaders(headers:_*)).get
+            val errors = new PetsFindByTagsGetValidator(tags).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" ) |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                    tags <- PetsFindByStatusGetStatusGenerator
+                } yield tags
+            val inputs = genInputs suchThat { tags =>
+                new PetsFindByTagsGetValidator(tags).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                tags <- PetsFindByStatusGetStatusGenerator
+            } yield tags
+            val inputs = genInputs suchThat { tags =>
+                new PetsFindByTagsGetValidator(tags).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+
+    "PUT /v2/users/{username}" should {
+        def testInvalidInput(input: (String, UsersUsernamePutBody)) = {
+
+            val (username, body) = input
+
+            val url = s"""/v2/users/${toPath(username)}"""
+            val headers = Seq()
+                val parsed_body = PlayBodyParsing.jacksonMapper("application/json").writeValueAsString(body)
+
+            val path = route(FakeRequest(PUT, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new UsersUsernamePutValidator(username, body).errors
+
+            lazy val validations = errors flatMap { _.messages } map { m => contentAsString(path).contains(m) ?= true }
+
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                requestStatusCode_(path) ?= BAD_REQUEST ,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.nonEmpty ?= true,
+                all(validations:_*)
+            )
+        }
+        def testValidInput(input: (String, UsersUsernamePutBody)) = {
+            val (username, body) = input
+            
+            val parsed_body = parserConstructor("application/json").writeValueAsString(body)
+            
+            val url = s"""/v2/users/${toPath(username)}"""
+            val headers = Seq()
+            val path = route(FakeRequest(PUT, url).withHeaders(headers:_*).withBody(parsed_body)).get
+            val errors = new UsersUsernamePutValidator(username, body).errors
+            val possibleResponseTypes: Map[Int,Class[Any]] = Map.empty[Int,Class[Any]]
+
+            val expectedCode = requestStatusCode_(path)
+            val expectedResponseType = possibleResponseTypes(expectedCode)
+
+            val parsedApiResponse = scala.util.Try {
+                parseResponseContent(requestContentAsString_(path), requestContentType_(path), expectedResponseType)
+            }
+            ("given an URL: [" + url + "]" + "and body [" + parsed_body + "]") |: all(
+                parsedApiResponse.isSuccess ?= true,
+                requestContentType_(path) ?= Some("application/json"),
+                errors.isEmpty ?= true
+            )
+        }
+        "discard invalid data" in new WithApplication {
+            val genInputs = for {
+                        username <- StringGenerator
+                        body <- UsersUsernamePutBodyGenerator
+                    
+                } yield (username, body)
+            val inputs = genInputs suchThat { case (username, body) =>
+                new UsersUsernamePutValidator(username, body).errors.nonEmpty
+            }
+            val props = forAll(inputs) { i => testInvalidInput(i) }
+            checkResult(props)
+        }
+        "do something with valid data" in new WithApplication {
+            val genInputs = for {
+                    username <- StringGenerator
+                    body <- UsersUsernamePutBodyGenerator
+                
+            } yield (username, body)
+            val inputs = genInputs suchThat { case (username, body) =>
+                new UsersUsernamePutValidator(username, body).errors.isEmpty
+            }
+            val props = forAll(inputs) { i => testValidInput(i) }
+            checkResult(props)
+        }
+
+    }
+}

--- a/compiler/src/test/resources/expected_results/types/split.petstore.api.yaml.types
+++ b/compiler/src/test/resources/expected_results/types/split.petstore.api.yaml.types
@@ -1,0 +1,218 @@
+⌿paths⌿/users/{username}⌿get⌿username ->
+	Str
+⌿paths⌿/pets/{petId}⌿post⌿status ->
+	Str
+⌿paths⌿/users/login⌿get⌿username ->
+	Opt(Str)
+⌿paths⌿/pets⌿post⌿body ->
+	Opt(TypeDef(⌿definitions⌿Pet, Seq(
+		Field(⌿definitions⌿Pet⌿name, Str), 
+		Field(⌿definitions⌿Pet⌿tags, Opt(Arr(TypeDef(⌿definitions⌿Tag, Seq(
+			Field(⌿definitions⌿Tag⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Tag⌿name, Opt(Str))))))), 
+		Field(⌿definitions⌿Pet⌿photoUrls, Arr(Str)), 
+		Field(⌿definitions⌿Pet⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿Pet⌿status, Opt(Str)), 
+		Field(⌿definitions⌿Pet⌿category, Opt(TypeDef(⌿definitions⌿Category, Seq(
+			Field(⌿definitions⌿Category⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Category⌿name, Opt(Str)))))))))
+⌿paths⌿/users/{username}⌿put⌿body ->
+	Opt(TypeDef(⌿definitions⌿User, Seq(
+		Field(⌿definitions⌿User⌿email, Opt(Str)), 
+		Field(⌿definitions⌿User⌿username, Opt(Str)), 
+		Field(⌿definitions⌿User⌿userStatus, Opt(Intgr)), 
+		Field(⌿definitions⌿User⌿lastName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿firstName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿User⌿phone, Opt(Str)), 
+		Field(⌿definitions⌿User⌿password, Opt(Str)))))
+⌿paths⌿/stores/order⌿post⌿body ->
+	Opt(TypeDef(⌿definitions⌿Order, Seq(
+		Field(⌿definitions⌿Order⌿shipDate, Opt(DateTime)), 
+		Field(⌿definitions⌿Order⌿quantity, Opt(Intgr)), 
+		Field(⌿definitions⌿Order⌿petId, Opt(Lng)), 
+		Field(⌿definitions⌿Order⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿Order⌿complete, Opt(Bool)), 
+		Field(⌿definitions⌿Order⌿status, Opt(Str)))))
+⌿paths⌿/pets/{petId}⌿post⌿petId ->
+	Str
+⌿paths⌿/pets/{petId}⌿delete⌿petId ->
+	Lng
+⌿paths⌿/pets/{petId}⌿delete⌿api_key ->
+	Str
+⌿paths⌿/users/login⌿get⌿password ->
+	Opt(Str)
+⌿paths⌿/pets/{petId}⌿post⌿name ->
+	Str
+⌿paths⌿/users/{username}⌿put⌿username ->
+	Str
+⌿paths⌿/users/createWithList⌿post⌿body ->
+	Opt(Arr(TypeDef(⌿definitions⌿User, Seq(
+		Field(⌿definitions⌿User⌿email, Opt(Str)), 
+		Field(⌿definitions⌿User⌿username, Opt(Str)), 
+		Field(⌿definitions⌿User⌿userStatus, Opt(Intgr)), 
+		Field(⌿definitions⌿User⌿lastName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿firstName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿User⌿phone, Opt(Str)), 
+		Field(⌿definitions⌿User⌿password, Opt(Str))))))
+⌿paths⌿/pets/findByStatus⌿get⌿status ->
+	Opt(Arr(Str))
+⌿paths⌿/pets⌿put⌿body ->
+	Opt(TypeDef(⌿definitions⌿Pet, Seq(
+		Field(⌿definitions⌿Pet⌿name, Str), 
+		Field(⌿definitions⌿Pet⌿tags, Opt(Arr(TypeDef(⌿definitions⌿Tag, Seq(
+			Field(⌿definitions⌿Tag⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Tag⌿name, Opt(Str))))))), 
+		Field(⌿definitions⌿Pet⌿photoUrls, Arr(Str)), 
+		Field(⌿definitions⌿Pet⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿Pet⌿status, Opt(Str)), 
+		Field(⌿definitions⌿Pet⌿category, Opt(TypeDef(⌿definitions⌿Category, Seq(
+			Field(⌿definitions⌿Category⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Category⌿name, Opt(Str)))))))))
+⌿paths⌿/pets/findByTags⌿get⌿tags ->
+	Opt(Arr(Str))
+⌿paths⌿/pets/{petId}⌿get⌿petId ->
+	Lng
+⌿paths⌿/stores/order/{orderId}⌿delete⌿orderId ->
+	Str
+⌿paths⌿/stores/order/{orderId}⌿get⌿orderId ->
+	Str
+⌿paths⌿/users⌿post⌿body ->
+	Opt(TypeDef(⌿definitions⌿User, Seq(
+		Field(⌿definitions⌿User⌿email, Opt(Str)), 
+		Field(⌿definitions⌿User⌿username, Opt(Str)), 
+		Field(⌿definitions⌿User⌿userStatus, Opt(Intgr)), 
+		Field(⌿definitions⌿User⌿lastName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿firstName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿User⌿phone, Opt(Str)), 
+		Field(⌿definitions⌿User⌿password, Opt(Str)))))
+⌿paths⌿/users/{username}⌿delete⌿username ->
+	Str
+⌿paths⌿/users/createWithArray⌿post⌿body ->
+	Opt(Arr(TypeDef(⌿definitions⌿User, Seq(
+		Field(⌿definitions⌿User⌿email, Opt(Str)), 
+		Field(⌿definitions⌿User⌿username, Opt(Str)), 
+		Field(⌿definitions⌿User⌿userStatus, Opt(Intgr)), 
+		Field(⌿definitions⌿User⌿lastName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿firstName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿User⌿phone, Opt(Str)), 
+		Field(⌿definitions⌿User⌿password, Opt(Str))))))
+⌿paths⌿/users/{username}⌿get⌿responses⌿200 ->
+	TypeDef(⌿definitions⌿User, Seq(
+		Field(⌿definitions⌿User⌿email, Opt(Str)), 
+		Field(⌿definitions⌿User⌿username, Opt(Str)), 
+		Field(⌿definitions⌿User⌿userStatus, Opt(Intgr)), 
+		Field(⌿definitions⌿User⌿lastName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿firstName, Opt(Str)), 
+		Field(⌿definitions⌿User⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿User⌿phone, Opt(Str)), 
+		Field(⌿definitions⌿User⌿password, Opt(Str))))
+⌿paths⌿/users/createWithList⌿post⌿responses⌿default ->
+	Null
+⌿paths⌿/users/{username}⌿get⌿responses⌿400 ->
+	Null
+⌿paths⌿/stores/order/{orderId}⌿get⌿responses⌿404 ->
+	Null
+⌿paths⌿/pets/findByTags⌿get⌿responses⌿400 ->
+	Null
+⌿paths⌿/pets⌿put⌿responses⌿400 ->
+	Null
+⌿paths⌿/users/login⌿get⌿responses⌿400 ->
+	Null
+⌿paths⌿/pets/findByStatus⌿get⌿responses⌿200 ->
+	ArrResult(TypeDef(⌿definitions⌿Pet, Seq(
+		Field(⌿definitions⌿Pet⌿name, Str), 
+		Field(⌿definitions⌿Pet⌿tags, Opt(ArrResult(TypeDef(⌿definitions⌿Tag, Seq(
+			Field(⌿definitions⌿Tag⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Tag⌿name, Opt(Str))))))), 
+		Field(⌿definitions⌿Pet⌿photoUrls, ArrResult(Str)), 
+		Field(⌿definitions⌿Pet⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿Pet⌿status, Opt(Str)), 
+		Field(⌿definitions⌿Pet⌿category, Opt(TypeDef(⌿definitions⌿Category, Seq(
+			Field(⌿definitions⌿Category⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Category⌿name, Opt(Str)))))))))
+⌿paths⌿/pets/{petId}⌿delete⌿responses⌿400 ->
+	Null
+⌿paths⌿/stores/order⌿post⌿responses⌿200 ->
+	TypeDef(⌿definitions⌿Order, Seq(
+		Field(⌿definitions⌿Order⌿shipDate, Opt(DateTime)), 
+		Field(⌿definitions⌿Order⌿quantity, Opt(Intgr)), 
+		Field(⌿definitions⌿Order⌿petId, Opt(Lng)), 
+		Field(⌿definitions⌿Order⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿Order⌿complete, Opt(Bool)), 
+		Field(⌿definitions⌿Order⌿status, Opt(Str))))
+⌿paths⌿/users/login⌿get⌿responses⌿200 ->
+	Str
+⌿paths⌿/stores/order⌿post⌿responses⌿400 ->
+	Null
+⌿paths⌿/stores/order/{orderId}⌿get⌿responses⌿200 ->
+	TypeDef(⌿definitions⌿Order, Seq(
+		Field(⌿definitions⌿Order⌿shipDate, Opt(DateTime)), 
+		Field(⌿definitions⌿Order⌿quantity, Opt(Intgr)), 
+		Field(⌿definitions⌿Order⌿petId, Opt(Lng)), 
+		Field(⌿definitions⌿Order⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿Order⌿complete, Opt(Bool)), 
+		Field(⌿definitions⌿Order⌿status, Opt(Str))))
+⌿paths⌿/pets⌿put⌿responses⌿404 ->
+	Null
+⌿paths⌿/users/logout⌿get⌿responses⌿default ->
+	Null
+⌿paths⌿/pets⌿post⌿responses⌿405 ->
+	Null
+⌿paths⌿/users/{username}⌿put⌿responses⌿404 ->
+	Null
+⌿paths⌿/users/{username}⌿delete⌿responses⌿400 ->
+	Null
+⌿paths⌿/pets/{petId}⌿get⌿responses⌿200 ->
+	TypeDef(⌿definitions⌿Pet, Seq(
+		Field(⌿definitions⌿Pet⌿name, Str), 
+		Field(⌿definitions⌿Pet⌿tags, Opt(ArrResult(TypeDef(⌿definitions⌿Tag, Seq(
+			Field(⌿definitions⌿Tag⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Tag⌿name, Opt(Str))))))), 
+		Field(⌿definitions⌿Pet⌿photoUrls, ArrResult(Str)), 
+		Field(⌿definitions⌿Pet⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿Pet⌿status, Opt(Str)), 
+		Field(⌿definitions⌿Pet⌿category, Opt(TypeDef(⌿definitions⌿Category, Seq(
+			Field(⌿definitions⌿Category⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Category⌿name, Opt(Str))))))))
+⌿paths⌿/stores/order/{orderId}⌿delete⌿responses⌿404 ->
+	Null
+⌿paths⌿/pets/findByTags⌿get⌿responses⌿200 ->
+	ArrResult(TypeDef(⌿definitions⌿Pet, Seq(
+		Field(⌿definitions⌿Pet⌿name, Str), 
+		Field(⌿definitions⌿Pet⌿tags, Opt(ArrResult(TypeDef(⌿definitions⌿Tag, Seq(
+			Field(⌿definitions⌿Tag⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Tag⌿name, Opt(Str))))))), 
+		Field(⌿definitions⌿Pet⌿photoUrls, ArrResult(Str)), 
+		Field(⌿definitions⌿Pet⌿id, Opt(Lng)), 
+		Field(⌿definitions⌿Pet⌿status, Opt(Str)), 
+		Field(⌿definitions⌿Pet⌿category, Opt(TypeDef(⌿definitions⌿Category, Seq(
+			Field(⌿definitions⌿Category⌿id, Opt(Lng)), 
+			Field(⌿definitions⌿Category⌿name, Opt(Str)))))))))
+⌿paths⌿/pets/{petId}⌿get⌿responses⌿400 ->
+	Null
+⌿paths⌿/users/{username}⌿put⌿responses⌿400 ->
+	Null
+⌿paths⌿/users/createWithArray⌿post⌿responses⌿default ->
+	Null
+⌿paths⌿/pets/{petId}⌿get⌿responses⌿404 ->
+	Null
+⌿paths⌿/pets/findByStatus⌿get⌿responses⌿400 ->
+	Null
+⌿paths⌿/stores/order/{orderId}⌿get⌿responses⌿400 ->
+	Null
+⌿paths⌿/stores/order/{orderId}⌿delete⌿responses⌿400 ->
+	Null
+⌿paths⌿/users/{username}⌿get⌿responses⌿404 ->
+	Null
+⌿paths⌿/pets/{petId}⌿post⌿responses⌿405 ->
+	Null
+⌿paths⌿/users/{username}⌿delete⌿responses⌿404 ->
+	Null
+⌿paths⌿/pets⌿put⌿responses⌿405 ->
+	Null
+⌿paths⌿/users⌿post⌿responses⌿default ->
+	Null

--- a/compiler/src/test/resources/expected_results/validation/split.petstore.api.yaml.scala
+++ b/compiler/src/test/resources/expected_results/validation/split.petstore.api.yaml.scala
@@ -1,0 +1,361 @@
+package split.petstore.api.yaml
+import play.api.mvc.{Action, Controller}
+import play.api.data.validation.Constraint
+import de.zalando.play.controllers._
+import PlayBodyParsing._
+import PlayValidations._
+import de.zalando.play.controllers.ArrayWrapper
+import org.joda.time.DateTime
+// ----- constraints and wrapper validations -----
+class UsersUsernameGetUsernameConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class UsersUsernameGetUsernameValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new UsersUsernameGetUsernameConstraints(instance))
+}
+class PetsPetIdPostStatusConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class PetsPetIdPostStatusValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new PetsPetIdPostStatusConstraints(instance))
+}
+class OrderStatusOptConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class OrderStatusOptValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new OrderStatusOptConstraints(instance))
+}
+class PetNameConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class PetNameValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new PetNameConstraints(instance))
+}
+class OrderPetIdOptConstraints(override val instance: Long) extends ValidationBase[Long] {
+    override def constraints: Seq[Constraint[Long]] =
+        Seq()
+}
+class OrderPetIdOptValidator(instance: Long) extends RecursiveValidator {
+    override val validators = Seq(new OrderPetIdOptConstraints(instance))
+}
+class PetPhotoUrlsArrConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class PetPhotoUrlsArrValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new PetPhotoUrlsArrConstraints(instance))
+}
+class OrderQuantityOptConstraints(override val instance: Int) extends ValidationBase[Int] {
+    override def constraints: Seq[Constraint[Int]] =
+        Seq()
+}
+class OrderQuantityOptValidator(instance: Int) extends RecursiveValidator {
+    override val validators = Seq(new OrderQuantityOptConstraints(instance))
+}
+class OrderShipDateOptConstraints(override val instance: DateTime) extends ValidationBase[DateTime] {
+    override def constraints: Seq[Constraint[DateTime]] =
+        Seq()
+}
+class OrderShipDateOptValidator(instance: DateTime) extends RecursiveValidator {
+    override val validators = Seq(new OrderShipDateOptConstraints(instance))
+}
+class OrderCompleteOptConstraints(override val instance: Boolean) extends ValidationBase[Boolean] {
+    override def constraints: Seq[Constraint[Boolean]] =
+        Seq()
+}
+class OrderCompleteOptValidator(instance: Boolean) extends RecursiveValidator {
+    override val validators = Seq(new OrderCompleteOptConstraints(instance))
+}
+class PetsPetIdPostPetIdConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class PetsPetIdPostPetIdValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new PetsPetIdPostPetIdConstraints(instance))
+}
+class PetsPetIdDeletePetIdConstraints(override val instance: Long) extends ValidationBase[Long] {
+    override def constraints: Seq[Constraint[Long]] =
+        Seq()
+}
+class PetsPetIdDeletePetIdValidator(instance: Long) extends RecursiveValidator {
+    override val validators = Seq(new PetsPetIdDeletePetIdConstraints(instance))
+}
+class PetsPetIdDeleteApi_keyConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class PetsPetIdDeleteApi_keyValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new PetsPetIdDeleteApi_keyConstraints(instance))
+}
+class PetsPetIdPostNameConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class PetsPetIdPostNameValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new PetsPetIdPostNameConstraints(instance))
+}
+class UsersUsernamePutUsernameConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class UsersUsernamePutUsernameValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new UsersUsernamePutUsernameConstraints(instance))
+}
+class PetsFindByStatusGetStatusOptArrConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class PetsFindByStatusGetStatusOptArrValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new PetsFindByStatusGetStatusOptArrConstraints(instance))
+}
+class PetsPetIdGetPetIdConstraints(override val instance: Long) extends ValidationBase[Long] {
+    override def constraints: Seq[Constraint[Long]] =
+        Seq()
+}
+class PetsPetIdGetPetIdValidator(instance: Long) extends RecursiveValidator {
+    override val validators = Seq(new PetsPetIdGetPetIdConstraints(instance))
+}
+class StoresOrderOrderIdDeleteOrderIdConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class StoresOrderOrderIdDeleteOrderIdValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new StoresOrderOrderIdDeleteOrderIdConstraints(instance))
+}
+class StoresOrderOrderIdGetOrderIdConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class StoresOrderOrderIdGetOrderIdValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new StoresOrderOrderIdGetOrderIdConstraints(instance))
+}
+class UsersUsernameDeleteUsernameConstraints(override val instance: String) extends ValidationBase[String] {
+    override def constraints: Seq[Constraint[String]] =
+        Seq()
+}
+class UsersUsernameDeleteUsernameValidator(instance: String) extends RecursiveValidator {
+    override val validators = Seq(new UsersUsernameDeleteUsernameConstraints(instance))
+}
+// ----- complex type validators -----
+class PetsPostBodyOptValidator(instance: Pet) extends RecursiveValidator {
+    override val validators = Seq(
+        new PetNameValidator(instance.name), 
+        new PetTagsValidator(instance.tags), 
+        new PetPhotoUrlsValidator(instance.photoUrls), 
+        new OrderPetIdValidator(instance.id), 
+        new OrderStatusValidator(instance.status), 
+        new PetCategoryValidator(instance.category)
+    )
+}
+class PetCategoryOptValidator(instance: PetCategoryOpt) extends RecursiveValidator {
+    override val validators = Seq(
+        new OrderPetIdValidator(instance.id), 
+        new OrderStatusValidator(instance.name)
+    )
+}
+class UsersUsernamePutBodyOptValidator(instance: User) extends RecursiveValidator {
+    override val validators = Seq(
+        new OrderStatusValidator(instance.email), 
+        new OrderStatusValidator(instance.username), 
+        new OrderQuantityValidator(instance.userStatus), 
+        new OrderStatusValidator(instance.lastName), 
+        new OrderStatusValidator(instance.firstName), 
+        new OrderPetIdValidator(instance.id), 
+        new OrderStatusValidator(instance.phone), 
+        new OrderStatusValidator(instance.password)
+    )
+}
+class StoresOrderPostBodyOptValidator(instance: Order) extends RecursiveValidator {
+    override val validators = Seq(
+        new OrderShipDateValidator(instance.shipDate), 
+        new OrderQuantityValidator(instance.quantity), 
+        new OrderPetIdValidator(instance.petId), 
+        new OrderPetIdValidator(instance.id), 
+        new OrderCompleteValidator(instance.complete), 
+        new OrderStatusValidator(instance.status)
+    )
+}
+// ----- option delegating validators -----
+class OrderStatusValidator(instance: OrderStatus) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new OrderStatusOptValidator(_) }
+}
+class PetsPostBodyValidator(instance: PetsPostBody) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new PetsPostBodyOptValidator(_) }
+}
+class PetTagsValidator(instance: PetTags) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new PetTagsOptValidator(_) }
+}
+class OrderPetIdValidator(instance: OrderPetId) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new OrderPetIdOptValidator(_) }
+}
+class PetCategoryValidator(instance: PetCategory) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new PetCategoryOptValidator(_) }
+}
+class UsersUsernamePutBodyValidator(instance: UsersUsernamePutBody) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new UsersUsernamePutBodyOptValidator(_) }
+}
+class OrderQuantityValidator(instance: OrderQuantity) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new OrderQuantityOptValidator(_) }
+}
+class StoresOrderPostBodyValidator(instance: StoresOrderPostBody) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new StoresOrderPostBodyOptValidator(_) }
+}
+class OrderShipDateValidator(instance: OrderShipDate) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new OrderShipDateOptValidator(_) }
+}
+class OrderCompleteValidator(instance: OrderComplete) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new OrderCompleteOptValidator(_) }
+}
+class UsersCreateWithListPostBodyValidator(instance: UsersCreateWithListPostBody) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new UsersCreateWithListPostBodyOptValidator(_) }
+}
+class PetsFindByStatusGetStatusValidator(instance: PetsFindByStatusGetStatus) extends RecursiveValidator {
+    override val validators = instance.toSeq.map { new PetsFindByStatusGetStatusOptValidator(_) }
+}
+// ----- array delegating validators -----
+class PetTagsOptConstraints(override val instance: PetTagsOpt) extends ValidationBase[PetTagsOpt] {
+    override def constraints: Seq[Constraint[PetTagsOpt]] =
+        Seq()
+}
+class PetTagsOptValidator(instance: PetTagsOpt) extends RecursiveValidator {
+    override val validators = new PetTagsOptConstraints(instance) +: instance.map { new PetCategoryOptValidator(_)}
+}
+class PetPhotoUrlsConstraints(override val instance: PetPhotoUrls) extends ValidationBase[PetPhotoUrls] {
+    override def constraints: Seq[Constraint[PetPhotoUrls]] =
+        Seq()
+}
+class PetPhotoUrlsValidator(instance: PetPhotoUrls) extends RecursiveValidator {
+    override val validators = new PetPhotoUrlsConstraints(instance) +: instance.map { new PetPhotoUrlsArrValidator(_)}
+}
+class UsersCreateWithListPostBodyOptConstraints(override val instance: UsersCreateWithListPostBodyOpt) extends ValidationBase[UsersCreateWithListPostBodyOpt] {
+    override def constraints: Seq[Constraint[UsersCreateWithListPostBodyOpt]] =
+        Seq()
+}
+class UsersCreateWithListPostBodyOptValidator(instance: UsersCreateWithListPostBodyOpt) extends RecursiveValidator {
+    override val validators = new UsersCreateWithListPostBodyOptConstraints(instance) +: instance.map { new UsersUsernamePutBodyOptValidator(_)}
+}
+class PetsFindByStatusGetStatusOptConstraints(override val instance: PetsFindByStatusGetStatusOpt) extends ValidationBase[PetsFindByStatusGetStatusOpt] {
+    override def constraints: Seq[Constraint[PetsFindByStatusGetStatusOpt]] =
+        Seq()
+}
+class PetsFindByStatusGetStatusOptValidator(instance: PetsFindByStatusGetStatusOpt) extends RecursiveValidator {
+    override val validators = new PetsFindByStatusGetStatusOptConstraints(instance) +: instance.map { new PetsFindByStatusGetStatusOptArrValidator(_)}
+}
+// ----- catch all simple validators -----
+// ----- call validations -----
+class UsersPostValidator(body: UsersUsernamePutBody) extends RecursiveValidator {
+    override val validators = Seq(
+        new UsersUsernamePutBodyValidator(body)
+    
+    )
+}
+class PetsPostValidator(body: PetsPostBody) extends RecursiveValidator {
+    override val validators = Seq(
+        new PetsPostBodyValidator(body)
+    
+    )
+}
+class PetsPutValidator(body: PetsPostBody) extends RecursiveValidator {
+    override val validators = Seq(
+        new PetsPostBodyValidator(body)
+    
+    )
+}
+class PetsFindByStatusGetValidator(status: PetsFindByStatusGetStatus) extends RecursiveValidator {
+    override val validators = Seq(
+        new PetsFindByStatusGetStatusValidator(status)
+    
+    )
+}
+class StoresOrderPostValidator(body: StoresOrderPostBody) extends RecursiveValidator {
+    override val validators = Seq(
+        new StoresOrderPostBodyValidator(body)
+    
+    )
+}
+class UsersCreateWithArrayPostValidator(body: UsersCreateWithListPostBody) extends RecursiveValidator {
+    override val validators = Seq(
+        new UsersCreateWithListPostBodyValidator(body)
+    
+    )
+}
+class UsersLoginGetValidator(username: OrderStatus, password: OrderStatus) extends RecursiveValidator {
+    override val validators = Seq(
+        new OrderStatusValidator(username), 
+    
+        new OrderStatusValidator(password)
+    
+    )
+}
+class StoresOrderOrderIdGetValidator(orderId: String) extends RecursiveValidator {
+    override val validators = Seq(
+        new StoresOrderOrderIdGetOrderIdValidator(orderId)
+    
+    )
+}
+class PetsPetIdGetValidator(petId: Long) extends RecursiveValidator {
+    override val validators = Seq(
+        new PetsPetIdGetPetIdValidator(petId)
+    
+    )
+}
+class UsersUsernameGetValidator(username: String) extends RecursiveValidator {
+    override val validators = Seq(
+        new UsersUsernameGetUsernameValidator(username)
+    
+    )
+}
+class UsersCreateWithListPostValidator(body: UsersCreateWithListPostBody) extends RecursiveValidator {
+    override val validators = Seq(
+        new UsersCreateWithListPostBodyValidator(body)
+    
+    )
+}
+class PetsPetIdPostValidator(petId: String, name: String, status: String) extends RecursiveValidator {
+    override val validators = Seq(
+        new PetsPetIdPostPetIdValidator(petId), 
+    
+        new PetsPetIdPostNameValidator(name), 
+    
+        new PetsPetIdPostStatusValidator(status)
+    
+    )
+}
+class UsersUsernameDeleteValidator(username: String) extends RecursiveValidator {
+    override val validators = Seq(
+        new UsersUsernameDeleteUsernameValidator(username)
+    
+    )
+}
+class StoresOrderOrderIdDeleteValidator(orderId: String) extends RecursiveValidator {
+    override val validators = Seq(
+        new StoresOrderOrderIdDeleteOrderIdValidator(orderId)
+    
+    )
+}
+class PetsPetIdDeleteValidator(api_key: String, petId: Long) extends RecursiveValidator {
+    override val validators = Seq(
+        new PetsPetIdDeleteApi_keyValidator(api_key), 
+    
+        new PetsPetIdDeletePetIdValidator(petId)
+    
+    )
+}
+class PetsFindByTagsGetValidator(tags: PetsFindByStatusGetStatus) extends RecursiveValidator {
+    override val validators = Seq(
+        new PetsFindByStatusGetStatusValidator(tags)
+    
+    )
+}
+class UsersUsernamePutValidator(username: String, body: UsersUsernamePutBody) extends RecursiveValidator {
+    override val validators = Seq(
+        new UsersUsernamePutUsernameValidator(username), 
+    
+        new UsersUsernamePutBodyValidator(body)
+    
+    )
+}

--- a/plugin/src/sbt-test/swagger/compile/conf/parts/split.petstore.definitions.json
+++ b/plugin/src/sbt-test/swagger/compile/conf/parts/split.petstore.definitions.json
@@ -1,0 +1,46 @@
+{
+  "definitions": {
+    "User": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "username": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "User Status"
+        }
+      }
+    },
+    "Category": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/plugin/src/sbt-test/swagger/compile/conf/parts/split.petstore.definitions.yaml
+++ b/plugin/src/sbt-test/swagger/compile/conf/parts/split.petstore.definitions.yaml
@@ -1,0 +1,72 @@
+definitions:
+  User:
+    properties:
+      id:
+        type: integer
+        format: int64
+      username:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      email:
+        type: string
+      password:
+        type: string
+      phone:
+        type: string
+      userStatus:
+        type: integer
+        format: int32
+        description: User Status
+  Pet:
+    required:
+      - name
+      - photoUrls
+    properties:
+      id:
+        type: integer
+        format: int64
+      category:
+        $ref: "split.petstore.definitions.json#/definitions/Category"
+      name:
+        type: string
+        example: doggie
+      photoUrls:
+        type: array
+        items:
+          type: string
+      tags:
+        type: array
+        items:
+          $ref: "#/definitions/Tag"
+      status:
+        type: string
+        description: pet status in the store
+  Tag:
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+  Order:
+    properties:
+      id:
+        type: integer
+        format: int64
+      petId:
+        type: integer
+        format: int64
+      quantity:
+        type: integer
+        format: int32
+      shipDate:
+        type: string
+        format: date-time
+      status:
+        type: string
+        description: Order Status
+      complete:
+        type: boolean

--- a/plugin/src/sbt-test/swagger/compile/conf/split.petstore.api.yaml
+++ b/plugin/src/sbt-test/swagger/compile/conf/split.petstore.api.yaml
@@ -1,0 +1,491 @@
+swagger: "2.0"
+info:
+  version: "1.0.0"
+  title: Swagger Petstore
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: apiteam@wordnik.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.wordnik.com
+basePath: /v2
+schemes:
+  - http
+x-api-first-error-mapping:
+  405:
+    - java.lang.IllegalArgumentException
+    - java.lang.IndexOutOfBoundsException
+paths:
+  /pets:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+      responses:
+        "405":
+          description: Validation exception
+        "404":
+          description: Pet not found
+        "400":
+          description: Invalid ID supplied
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma seperated strings
+      operationId: findPetsByStatus
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: status
+          description: Status values that need to be considered for filter
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: tags
+          description: Tags to filter by
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /pets/{petId}:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
+      operationId: getPetById
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: petId
+          description: ID of pet that needs to be fetched
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "404":
+          description: Pet not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Pet"
+        "400":
+          description: Invalid ID supplied
+      security:
+        - api_key: []
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ""
+      operationId: updatePetWithForm
+      consumes:
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: petId
+          description: ID of pet that needs to be updated
+          required: true
+          type: string
+        - in: formData
+          name: name
+          description: Updated name of the pet
+          required: true
+          type: string
+        - in: formData
+          name: status
+          description: Updated status of the pet
+          required: true
+          type: string
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ""
+      operationId: deletePet
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: header
+          name: api_key
+          description: ""
+          required: true
+          type: string
+        - in: path
+          name: petId
+          description: Pet id to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+          - write_pets
+          - read_pets
+  /stores/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: order placed for purchasing the pet
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Order"
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Order"
+        "400":
+          description: Invalid Order
+  /stores/order/{orderId}:
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+      operationId: getOrderById
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: orderId
+          description: ID of pet that needs to be fetched
+          required: true
+          type: string
+      responses:
+        "404":
+          description: Order not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/Order"
+        "400":
+          description: Invalid ID supplied
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: orderId
+          description: ID of the order that needs to be deleted
+          required: true
+          type: string
+      responses:
+        "404":
+          description: Order not found
+        "400":
+          description: Invalid ID supplied
+  /users:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: Created user object
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithArrayInput
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: List of user object
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: body
+          description: List of user object
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+      responses:
+        default:
+          description: successful operation
+  /users/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: query
+          name: username
+          description: The user name for login
+          required: false
+          type: string
+        - in: query
+          name: password
+          description: The password for login in clear text
+          required: false
+          type: string
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: string
+        "400":
+          description: Invalid username/password supplied
+  /users/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        default:
+          description: successful operation
+  /users/{username}:
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          type: string
+      responses:
+        "404":
+          description: User not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+        "400":
+          description: Invalid username supplied
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: name that need to be deleted
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Updated user object
+          required: false
+          schema:
+            $ref: "parts/split.petstore.definitions.yaml#/definitions/User"
+      responses:
+        "404":
+          description: User not found
+        "400":
+          description: Invalid user supplied
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be deleted
+          required: true
+          type: string
+      responses:
+        "404":
+          description: User not found
+        "400":
+          description: Invalid username supplied
+securityDefinitions:
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header
+  petstore_auth:
+    type: oauth2
+    authorizationUrl: http://petstore.swagger.wordnik.com/api/oauth/dialog
+    flow: implicit
+    scopes:
+      write_pets: modify pets in your account
+      read_pets: read your pets
+

--- a/travis/jvmopts
+++ b/travis/jvmopts
@@ -1,6 +1,6 @@
 -Dfile.encoding=UTF8
--Xms1024M
--Xmx1024M
+-Xms512M
+-Xmx512M
 -Xss6M
 -XX:MaxPermSize=256M
 -XX:ReservedCodeCacheSize=256M

--- a/travis/jvmopts
+++ b/travis/jvmopts
@@ -1,0 +1,6 @@
+-Dfile.encoding=UTF8
+-Xms1024M
+-Xmx1024M
+-Xss6M
+-XX:MaxPermSize=256M
+-XX:ReservedCodeCacheSize=256M


### PR DESCRIPTION
- Fixed naming schema in the way so that it produces correct names for definitions linked from another files
- Created test case with specification split across three files, two ```yaml``` and one ```json```