### PR TITLE
#85, fix: Incorrect result produced by code generation part

### DIFF
--- a/compiler/src/main/scala/de/zalando/apifirst/generators/playScala.scala
+++ b/compiler/src/main/scala/de/zalando/apifirst/generators/playScala.scala
@@ -121,7 +121,6 @@ class ScalaGenerator(val strictModel: StrictModel) extends PlayScalaControllerAn
       "unmanaged_imports"   -> unmanagedImports.map(i => Map("name" -> i))
     )
 
-
     val singlePackage = Map(
       "classes"             -> ReShaper.filterByType("classes", denotationTable),
       "aliases"             -> ReShaper.filterByType("aliases", denotationTable),
@@ -267,7 +266,7 @@ trait PlayScalaControllersGenerator {
       val method = table(call.asReference)("controller")
       val methodWithCode = method + (
         "dead_code"       -> unmanagedParts.get(call).map(_.deadCode).getOrElse(""),
-        "implementation"  -> unmanagedParts.get(call).map(_.relevantCode).getOrElse("Failure(???)")
+        "implementation"  -> unmanagedParts.get(call).map(_.relevantCode.trim).getOrElse("Failure(???)")
         )
       methodWithCode
     }

--- a/compiler/src/main/scala/de/zalando/play/compiler/swaggerCompiler.scala
+++ b/compiler/src/main/scala/de/zalando/play/compiler/swaggerCompiler.scala
@@ -92,22 +92,23 @@ object SwaggerCompiler {
     val fileName: String = fullFileName(task, directory)
     val fileContents = readFile(outputDir, fileName)
     val canWrite = overwrite || fileContents.isEmpty
-    if (fileContents != content && canWrite)
-      Seq(writeToFile(outputDir)(fileName, content))
-    else
+    if (canWrite) {
+      val file = new File(outputDir, fileName)
+      if (fileContents != content) writeToFile(file, content)
+      Seq(file)
+    } else {
       Seq.empty[File]
+    }
   }
 
   def fullFileName(task: Option[SwaggerCompilationTask], directory: String): String =
     directory + task.map { _.definitionFile.getName + ".scala" }.getOrElse("")
 
-  def writeToFile(outputDir: File) = (filename: String, content: String) => {
-    val file = new File(outputDir, filename)
+  def writeToFile(file: File, content: String): Unit = {
     val parent = file.getParentFile
     if (parent.exists && parent.isFile) parent.renameTo(new File(parent.getAbsolutePath + ".backup"))
     if (!parent.exists) parent.mkdirs()
     FileUtils.writeStringToFile(file, content, implicitly[Codec].name)
-    file
   }
 
   def readFile(outputDir: File, fileName: String) = {

--- a/plugin/src/main/scala/de/zalando/play/swagger/sbt/PlaySwagger.scala
+++ b/plugin/src/main/scala/de/zalando/play/swagger/sbt/PlaySwagger.scala
@@ -64,6 +64,9 @@ object PlaySwagger extends AutoPlugin {
       "org.scalacheck" %% "scalacheck" % "1.12.4" % Test,
       "com.typesafe.play" %% "play-test" % play.core.PlayVersion.current % Test
     )
+  ) ++ Seq(
+    managedSourceDirectories in Compile += crossTarget.value / "routes" / Defaults.nameForSrc(Compile.name),
+    managedSourceDirectories in Test += crossTarget.value / "routes" / Defaults.nameForSrc(Test.name)
   ) ++ inConfig(Compile)(rawSwaggerSettings) ++
     inConfig(Test)(rawSwaggerSettings) ++
     inConfig(Compile)(swaggerBaseSettings) ++
@@ -108,7 +111,7 @@ object PlaySwagger extends AutoPlugin {
 
   def swaggerBaseSettings: Seq[Setting[_]] = Seq(
     target in swaggerBase := crossTarget.value / "routes" / Defaults.nameForSrc(Compile.name),
-    swaggerBase  := swaggerGenerateBase.value,
+    swaggerBase := swaggerGenerateBase.value,
     managedSources ++= swaggerBase.value
   )
   def swaggerTestSettings: Seq[Setting[_]] = Seq(
@@ -161,14 +164,9 @@ object PlaySwagger extends AutoPlugin {
 
       // Read the detailed scaladoc for syncIncremental to see how it works
       val (products, errors) = syncIncremental(cacheDirectory, tasks) { tasksToRun: Seq[SwaggerCompilationTask] =>
-
-        // TODO sometimes tasksToRun are empty here, even if tasks are not
-        // streams.value.log.verbose("SyncInc in " + config.key.label + tasksToRun.map(_.definitionFile.name).mkString(", "))
-
         val results = tasksToRun map { task =>
             task -> Try { compiler(task, outputDirectory, swaggerKeyPrefix.value, routesImport) }
         }
-
         // Collect the results into a map of task to OpResult for syncIncremental
         val taskResults: Map[SwaggerCompilationTask, OpResult] = results.map {
           case (task, Success(result)) =>
@@ -182,11 +180,9 @@ object PlaySwagger extends AutoPlugin {
         }
         (taskResults, errors)
       }
-
-      if (errors.nonEmpty) throw errors.head
-
-      // Return all the files that were or have in the past been compiled
-      products.to[Seq]
+      if (errors.nonEmpty)
+        throw errors.head
+      else
+        products.to[Seq]
     }
-
 }


### PR DESCRIPTION
Fixed incorrect result returned by code generation part.

Broken implementation had compared existing files with generated and if they were identical didn't returned anything. This triggered syncIncremental to delete existing files.